### PR TITLE
NF-43 - Restrict access to front-end service to logged in GG user

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/config/AppConfig.scala
@@ -32,4 +32,7 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val cy: String            = "cy"
   val defaultLanguage: Lang = Lang(en)
 
+  lazy val loginUrl: String         = config.get[String]("urls.login")
+  lazy val loginContinueUrl: String = config.get[String]("urls.loginContinue")
+
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/config/Module.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/config/Module.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +12,19 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config
 
-@this(layout: Layout)
+import com.google.inject.AbstractModule
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.{
+  AuthenticatedIdentifierAction,
+  IdentifierAction
+}
 
-@()(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+class Module extends AbstractModule {
 
-@layout(pageTitle = Some("national-import-duty-adjustment-centre-frontend")) {
-    <h1 class="govuk-heading-xl">national-import-duty-adjustment-centre-frontend</h1>
-    <p class="govuk-body">@{messages("service.text")}</p>
+  override def configure(): Unit =
+    bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()
+
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/SessionExpiredController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/SessionExpiredController.scala
@@ -17,25 +17,18 @@
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
 
 import javax.inject.{Inject, Singleton}
-
 import play.api.mvc._
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.SessionExpiredPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.HelloWorldPage
 
 import scala.concurrent.Future
 
 @Singleton
-class HelloWorldController @Inject() (
-  appConfig: AppConfig,
-  mcc: MessagesControllerComponents,
-  helloWorldPage: HelloWorldPage
-) extends FrontendController(mcc) {
+class SessionExpiredController @Inject() (mcc: MessagesControllerComponents, sessionExpiredPage: SessionExpiredPage)
+    extends FrontendController(mcc) {
 
-  implicit val config: AppConfig = appConfig
-
-  val helloWorld: Action[AnyContent] = Action.async { implicit request =>
-    Future.successful(Ok(helloWorldPage()))
+  val onPageLoad: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(sessionExpiredPage()))
   }
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartController.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.i18n.I18nSupport
+import play.api.mvc._
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.Future
+
+@Singleton
+class StartController @Inject() (mcc: MessagesControllerComponents, identify: IdentifierAction, startPage: StartPage)
+    extends FrontendController(mcc) with I18nSupport {
+
+  val onPageLoad: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(startPage()))
+  }
+
+  val onPageLoadAuthorised: Action[AnyContent] = identify { implicit request =>
+    Ok(startPage())
+  }
+
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/UnauthorisedController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/UnauthorisedController.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc._
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.UnauthorisedPage
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import scala.concurrent.Future
+
+@Singleton
+class UnauthorisedController @Inject() (mcc: MessagesControllerComponents, unauthorisedPage: UnauthorisedPage)
+    extends FrontendController(mcc) {
+
+  val onPageLoad: Action[AnyContent] = Action.async { implicit request =>
+    Future.successful(Ok(unauthorisedPage()))
+  }
+
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/IdentifierAction.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/IdentifierAction.scala
@@ -17,13 +17,13 @@
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions
 
 import com.google.inject.Inject
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes
 import play.api.mvc.Results._
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
 import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests.IdentifierRequest
 import uk.gov.hmrc.play.HeaderCarrierConverter
 
@@ -53,25 +53,6 @@ class AuthenticatedIdentifierAction @Inject() (
         Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))
       case _: AuthorisationException =>
         Redirect(routes.UnauthorisedController.onPageLoad())
-    }
-  }
-
-}
-
-class SessionIdentifierAction @Inject() (config: AppConfig, val parser: BodyParsers.Default)(implicit
-  val executionContext: ExecutionContext
-) extends IdentifierAction {
-
-  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
-
-    implicit val hc: HeaderCarrier =
-      HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
-
-    hc.sessionId match {
-      case Some(session) =>
-        block(IdentifierRequest(request, session.value))
-      case None =>
-        Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
     }
   }
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/IdentifierAction.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/IdentifierAction.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions
+
+import com.google.inject.Inject
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes
+import play.api.mvc.Results._
+import play.api.mvc._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests.IdentifierRequest
+import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait IdentifierAction
+    extends ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]
+
+class AuthenticatedIdentifierAction @Inject() (
+  override val authConnector: AuthConnector,
+  config: AppConfig,
+  val parser: BodyParsers.Default
+)(implicit val executionContext: ExecutionContext)
+    extends IdentifierAction with AuthorisedFunctions {
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
+
+    implicit val hc: HeaderCarrier =
+      HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+
+    authorised().retrieve(Retrievals.internalId) {
+      _.map {
+        internalId => block(IdentifierRequest(request, internalId))
+      }.getOrElse(throw new UnauthorizedException("Unable to retrieve internal Id"))
+    } recover {
+      case _: NoActiveSession =>
+        Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))
+      case _: AuthorisationException =>
+        Redirect(routes.UnauthorisedController.onPageLoad())
+    }
+  }
+
+}
+
+class SessionIdentifierAction @Inject() (config: AppConfig, val parser: BodyParsers.Default)(implicit
+  val executionContext: ExecutionContext
+) extends IdentifierAction {
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
+
+    implicit val hc: HeaderCarrier =
+      HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+
+    hc.sessionId match {
+      case Some(session) =>
+        block(IdentifierRequest(request, session.value))
+      case None =>
+        Future.successful(Redirect(routes.SessionExpiredController.onPageLoad()))
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/requests/IdentifierRequest.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/requests/IdentifierRequest.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,19 +12,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes.LanguageSwitchController._
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcLanguageSelect
-@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageSelect
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests
 
-@this(hmrcLanguageSelect: HmrcLanguageSelect)
+import play.api.mvc.{Request, WrappedRequest}
 
-@()(implicit messages: Messages)
-@hmrcLanguageSelect(LanguageSelect(
-    if (messages.lang.code == "cy") Cy else En,
-    (En, switchToLanguage("en").url),
-    (Cy, switchToLanguage("cy").url)
-))
-
+case class IdentifierRequest[A](request: Request[A], identifier: String) extends WrappedRequest[A](request)

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/ErrorTemplate.scala.html
@@ -18,6 +18,8 @@
 
 @(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
 @layout(pageTitle = Some(pageTitle)) {
-    <h1 class="govuk-heading-xl">@{Text(heading).asHtml}</h1>
-    <p class="govuk-body">@{Text(message).asHtml}</p>
+
+    @components.heading(heading)
+    @components.paragraph(message)
+
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/ErrorTemplate.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/ErrorTemplate.scala.html
@@ -14,11 +14,9 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-
 @this(layout: Layout)
 
-@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+@(pageTitle: String, heading: String, message: String)(implicit request: Request[_], messages: Messages)
 @layout(pageTitle = Some(pageTitle)) {
     <h1 class="govuk-heading-xl">@{Text(heading).asHtml}</h1>
     <p class="govuk-body">@{Text(message).asHtml}</p>

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/Layout.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/Layout.scala.html
@@ -21,12 +21,13 @@
         govukLayout: GovukLayout,
         head: Head,
         hmrcStandardFooter: HmrcStandardFooter,
-        languageSelect: LanguageSelect
+        languageSelect: LanguageSelect,
+        appConfig: AppConfig
 )
 @(pageTitle: Option[String] = None,
         headBlock: Option[Html] = None,
         scriptsBlock: Option[Html] = None
-)(contentBlock: Html)(implicit request: Request[_], messages: Messages, appConfig: AppConfig)
+)(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
 @beforeContentBlock = {
     @if(appConfig.welshLanguageSupportEnabled) {@languageSelect()}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPage.scala.html
@@ -14,17 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes.LanguageSwitchController._
 @import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcLanguageSelect
-@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageSelect
 
-@this(hmrcLanguageSelect: HmrcLanguageSelect)
+@this(layout: Layout)
 
-@()(implicit messages: Messages)
-@hmrcLanguageSelect(LanguageSelect(
-    if (messages.lang.code == "cy") Cy else En,
-    (En, switchToLanguage("en").url),
-    (Cy, switchToLanguage("cy").url)
-))
+@()(implicit request: Request[_], messages: Messages)
 
+@layout(pageTitle = Some(messages("session_expired.title"))) {
+    <h1 class="govuk-heading-xl">@messages("session_expired.heading")</h1>
+    <p class="govuk-body">@messages("session_expired.guidance")</p>
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPage.scala.html
@@ -18,7 +18,8 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = Some(messages("session_expired.title"))) {
-    <h1 class="govuk-heading-xl">@messages("session_expired.title")</h1>
-    <p class="govuk-body">@messages("session_expired.guidance")</p>
-}
+    @layout(pageTitle = Some(messages("session_expired.title"))) {
+
+        @components.heading(messages("session_expired.title"))
+        @components.paragraph(messages("session_expired.guidance"))
+    }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPage.scala.html
@@ -14,13 +14,11 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-
 @this(layout: Layout)
 
 @()(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = Some(messages("session_expired.title"))) {
-    <h1 class="govuk-heading-xl">@messages("session_expired.heading")</h1>
+    <h1 class="govuk-heading-xl">@messages("session_expired.title")</h1>
     <p class="govuk-body">@messages("session_expired.guidance")</p>
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/StartPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/StartPage.scala.html
@@ -14,17 +14,13 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes.LanguageSwitchController._
 @import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcLanguageSelect
-@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageSelect
 
-@this(hmrcLanguageSelect: HmrcLanguageSelect)
+@this(layout: Layout)
 
-@()(implicit messages: Messages)
-@hmrcLanguageSelect(LanguageSelect(
-    if (messages.lang.code == "cy") Cy else En,
-    (En, switchToLanguage("en").url),
-    (Cy, switchToLanguage("cy").url)
-))
+@()(implicit request: Request[_], messages: Messages)
 
+@layout(pageTitle = Some(messages("start_page.title"))) {
+    <h1 class="govuk-heading-xl">@messages("start_page.title")</h1>
+    <p class="govuk-body">@{messages("start_page.guidance")}</p>
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/UnauthorisedPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/UnauthorisedPage.scala.html
@@ -14,12 +14,11 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-
 @this(layout: Layout)
 
 @()(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = Some(messages("unauthorised.title"))) {
- <h1 class="govuk-heading-xl">@messages("unauthorised.title")</h1>
-}
+    @layout(pageTitle = Some(messages("unauthorised.title"))) {
+
+        @components.heading(messages("unauthorised.title"))
+    }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/UnauthorisedPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/UnauthorisedPage.scala.html
@@ -14,17 +14,12 @@
  * limitations under the License.
  *@
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes.LanguageSwitchController._
 @import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-@import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcLanguageSelect
-@import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.LanguageSelect
 
-@this(hmrcLanguageSelect: HmrcLanguageSelect)
+@this(layout: Layout)
 
-@()(implicit messages: Messages)
-@hmrcLanguageSelect(LanguageSelect(
-    if (messages.lang.code == "cy") Cy else En,
-    (En, switchToLanguage("en").url),
-    (Cy, switchToLanguage("cy").url)
-))
+@()(implicit request: Request[_], messages: Messages)
 
+@layout(pageTitle = Some(messages("unauthorised.title"))) {
+ <h1 class="govuk-heading-xl">@messages("unauthorised.heading")</h1>
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/components/heading.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/components/heading.scala.html
@@ -14,12 +14,6 @@
  * limitations under the License.
  *@
 
-@this(layout: Layout)
+@(content: String)
 
-@()(implicit request: Request[_], messages: Messages)
-
-    @layout(pageTitle = Some(messages("start_page.title"))) {
-
-        @components.heading(messages("start_page.title"))
-        @components.paragraph(messages("start_page.guidance"))
-    }
+<h1 class="govuk-heading-xl">@{Text(content).asHtml}</h1>

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/components/paragraph.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/components/paragraph.scala.html
@@ -14,12 +14,6 @@
  * limitations under the License.
  *@
 
-@this(layout: Layout)
+@(content: String)
 
-@()(implicit request: Request[_], messages: Messages)
-
-    @layout(pageTitle = Some(messages("start_page.title"))) {
-
-        @components.heading(messages("start_page.title"))
-        @components.paragraph(messages("start_page.guidance"))
-    }
+<p class="govuk-body">@{Text(content).asHtml}</p>

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     ".*(BuildInfo|Routes|Options|LanguageSwitchController|LanguageSelect).*",
     "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 83,
+  coverageMinimum := 82.5,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -34,3 +34,19 @@ lazy val microservice = Project(appName, file("."))
   .configs(IntegrationTest)
   .settings(integrationTestSettings(): _*)
   .settings(resolvers += Resolver.jcenterRepo)
+  .settings(scoverageSettings)
+
+lazy val scoverageSettings: Seq[Setting[_]] = Seq(
+  coverageExcludedPackages := List(
+    "<empty>",
+    "Reverse.*",
+    "metrics\\..*",
+    "test\\..*",
+    ".*(BuildInfo|Routes|Options).*",
+    "logger.*\\(.*\\)"
+  ).mkString(";"),
+  coverageMinimum := 55,  // TODO - improve this
+  coverageFailOnMinimum := true,
+  coverageHighlighting := true,
+  parallelExecution in Test := false
+)

--- a/build.sbt
+++ b/build.sbt
@@ -42,10 +42,10 @@ lazy val scoverageSettings: Seq[Setting[_]] = Seq(
     "Reverse.*",
     "metrics\\..*",
     "test\\..*",
-    ".*(BuildInfo|Routes|Options).*",
+    ".*(BuildInfo|Routes|Options|LanguageSwitchController|LanguageSelect).*",
     "logger.*\\(.*\\)"
   ).mkString(";"),
-  coverageMinimum := 55,  // TODO - improve this
+  coverageMinimum := 83,
   coverageFailOnMinimum := true,
   coverageHighlighting := true,
   parallelExecution in Test := false

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,7 +1,10 @@
 # microservice specific routes
 
-->         /govuk-frontend          govuk.Routes
-->         /hmrc-frontend           hmrcfrontend.Routes
-GET        /hello-world             uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.HelloWorldController.helloWorld
-GET        /language/:lang          uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.LanguageSwitchController.switchToLanguage(lang: String)
-GET        /assets/*file            controllers.Assets.versioned(path = "/public", file: Asset)
+->         /govuk-frontend                     govuk.Routes
+->         /hmrc-frontend                      hmrcfrontend.Routes
+GET        /                                   uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.StartController.onPageLoad
+GET        /authorised                         uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.StartController.onPageLoadAuthorised
+GET        /unauthorised                       uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.UnauthorisedController.onPageLoad
+GET        /this-service-has-been-reset        uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.SessionExpiredController.onPageLoad
+GET        /language/:lang                     uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.LanguageSwitchController.switchToLanguage(lang: String)
+GET        /assets/*file                       controllers.Assets.versioned(path = "/public", file: Asset)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -3,7 +3,6 @@
 ->         /govuk-frontend                     govuk.Routes
 ->         /hmrc-frontend                      hmrcfrontend.Routes
 GET        /                                   uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.StartController.onPageLoad
-GET        /authorised                         uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.StartController.onPageLoadAuthorised
 GET        /unauthorised                       uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.UnauthorisedController.onPageLoad
 GET        /this-service-has-been-reset        uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.SessionExpiredController.onPageLoad
 GET        /language/:lang                     uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.LanguageSwitchController.switchToLanguage(lang: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -46,6 +46,8 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline'
 # Play Modules
 # ~~~~
 # Additional play modules can be added here
+play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuthModule"
+play.modules.enabled += "uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.Module"
 
 # Secret key
 # ~~~~~
@@ -67,6 +69,10 @@ microservice {
   }
 
   services {
+    auth {
+      host = localhost
+      port = 8500
+    }
     contact-frontend {
       protocol = http
       host = localhost
@@ -119,4 +125,7 @@ play.i18n.langs = ["en", "cy"]
 # Change this value to true to enable Welsh translations to be loaded from messages.cy, and to display the language toggle
 features.welsh-language-support = false
 
-
+urls {
+  login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
+  loginContinue = "http://localhost:8490/national-import-duty-adjustment-centre"
+}

--- a/conf/messages
+++ b/conf/messages
@@ -1,3 +1,12 @@
-service.name = national-import-duty-adjustment-centre-frontend
-service.homePageUrl = /national-import-duty-adjustment-centre-frontend
-service.text = This is your new service
+service.name = National Import Duty Adjustment Centre
+service.homePageUrl = /national-import-duty-adjustment-centre
+
+start_page.title = Welcome
+start_page.guidance = This is your new service.
+
+session_expired.title = For your security, this service has been reset
+session_expired.heading = For your security, this service has been reset
+session_expired.guidance = The details you have given have been deleted because you did not continue the service for 15 minutes.
+
+unauthorised.title = You can’t access this service with this account
+unauthorised.heading = You can’t access this service with this account

--- a/conf/messages
+++ b/conf/messages
@@ -5,8 +5,6 @@ start_page.title = Welcome
 start_page.guidance = This is your new service.
 
 session_expired.title = For your security, this service has been reset
-session_expired.heading = For your security, this service has been reset
 session_expired.guidance = The details you have given have been deleted because you did not continue the service for 15 minutes.
 
 unauthorised.title = You can’t access this service with this account
-unauthorised.heading = You can’t access this service with this account

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,23 +1,23 @@
 import play.core.PlayVersion.current
-import play.sbt.PlayImport._
-import sbt.Keys.libraryDependencies
 import sbt._
 
 object AppDependencies {
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-frontend-play-27" % "3.2.0",
-    "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "0.34.0-play-27",
-    "uk.gov.hmrc"             %% "play-frontend-govuk"        % "0.56.0-play-27",
-    "uk.gov.hmrc"             %% "play-language"              % "4.5.0-play-27"
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-27" % "3.2.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "0.34.0-play-27",
+    "uk.gov.hmrc" %% "play-frontend-govuk"        % "0.56.0-play-27",
+    "uk.gov.hmrc" %% "play-language"              % "4.5.0-play-27"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-27"   % "3.2.0" % Test,
-    "org.scalatest"           %% "scalatest"                % "3.2.3"  % Test,
-    "org.jsoup"               %  "jsoup"                    % "1.13.1" % Test,
-    "com.typesafe.play"       %% "play-test"                % current  % Test,
-    "com.vladsch.flexmark"    %  "flexmark-all"             % "0.36.8" % "test, it",
-    "org.scalatestplus.play"  %% "scalatestplus-play"       % "4.0.3"  % "test, it"
+    "uk.gov.hmrc"            %% "bootstrap-test-play-27" % "3.2.0"  % Test,
+    "org.scalatest"          %% "scalatest"              % "3.2.3"  % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play"     % "3.1.2"  % Test,
+    "org.jsoup"               % "jsoup"                  % "1.13.1" % Test,
+    "com.typesafe.play"      %% "play-test"              % current  % Test,
+    "com.vladsch.flexmark"    % "flexmark-all"           % "0.36.8" % "test, it",
+    "org.scalatestplus.play" %% "scalatestplus-play"     % "4.0.3"  % "test, it"
   )
+
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -11,13 +11,14 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-27" % "3.2.0"  % Test,
-    "org.scalatest"          %% "scalatest"              % "3.2.3"  % Test,
-    "org.scalatestplus.play" %% "scalatestplus-play"     % "3.1.2"  % Test,
-    "org.jsoup"               % "jsoup"                  % "1.13.1" % Test,
-    "com.typesafe.play"      %% "play-test"              % current  % Test,
-    "com.vladsch.flexmark"    % "flexmark-all"           % "0.36.8" % "test, it",
-    "org.scalatestplus.play" %% "scalatestplus-play"     % "4.0.3"  % "test, it"
+    "uk.gov.hmrc"            %% "bootstrap-test-play-27" % "3.2.0"   % Test,
+    "org.scalatest"          %% "scalatest"              % "3.2.3"   % Test,
+    "org.scalatestplus.play" %% "scalatestplus-play"     % "3.1.2"   % Test,
+    "org.scalatestplus"      %% "mockito-3-4"            % "3.2.3.0" % Test,
+    "org.jsoup"               % "jsoup"                  % "1.13.1"  % Test,
+    "com.typesafe.play"      %% "play-test"              % current   % Test,
+    "com.vladsch.flexmark"    % "flexmark-all"           % "0.36.8"  % "test, it",
+    "org.scalatestplus.play" %% "scalatestplus-play"     % "4.0.3"   % "test, it"
   )
 
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/ControllerSpec.scala
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base
 
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.FakeIdentifierActions
 
 trait ControllerSpec extends UnitSpec with MockitoSugar with FakeIdentifierActions with BeforeAndAfterEach {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/UnitSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/UnitSpec.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2021 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +12,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base
 
-@this(layout: Layout)
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-@()(implicit request: Request[_], messages: Messages)
-
-@layout(pageTitle = Some(messages("unauthorised.title"))) {
- <h1 class="govuk-heading-xl">@messages("unauthorised.title")</h1>
-}
+trait UnitSpec extends AnyWordSpec with Matchers {}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/UnitViewSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/UnitViewSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base
+
+import play.api.i18n.{Lang, Messages, MessagesApi}
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.CSRFTokenHelper.CSRFRequest
+import play.api.test.FakeRequest
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.utils.Injector
+
+trait UnitViewSpec extends UnitSpec with ViewMatchers with Injector {
+
+  implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  val realMessagesApi: MessagesApi = instanceOf[MessagesApi]
+
+  protected implicit def messages(implicit request: Request[_]): Messages =
+    new AllMessageKeysAreMandatoryMessages(realMessagesApi.preferred(request))
+
+  protected def messages(key: String, args: Any*)(implicit request: Request[_]): String =
+    messages(request)(key, args: _*)
+
+}
+
+private class AllMessageKeysAreMandatoryMessages(msg: Messages) extends Messages {
+
+  override def asJava: play.i18n.Messages = msg.asJava
+
+  override def messages: Messages = msg.messages
+
+  override def lang: Lang = msg.lang
+
+  override def apply(key: String, args: Any*): String =
+    if (msg.isDefinedAt(key))
+      msg.apply(key, args: _*)
+    else throw new AssertionError(s"Message Key is not configured for {$key}")
+
+  override def apply(keys: Seq[String], args: Any*): String =
+    if (keys.exists(key => !msg.isDefinedAt(key)))
+      msg.apply(keys, args)
+    else throw new AssertionError(s"Message Key is not configured for {$keys}")
+
+  override def translate(key: String, args: Seq[Any]): Option[String] = msg.translate(key, args)
+
+  override def isDefinedAt(key: String): Boolean = msg.isDefinedAt(key)
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/ViewMatchers.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/ViewMatchers.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.{Document, Element}
+import org.jsoup.select.Elements
+import org.scalatest.matchers.must.Matchers
+import play.api.mvc.Result
+import play.api.test.Helpers.{contentAsString, _}
+import play.twirl.api.Html
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Future
+
+trait ViewMatchers extends Matchers {
+
+  implicit private def elements2Scala(elements: Elements): Iterator[Element] = elements.iterator().asScala
+  implicit protected def htmlBodyOf(html: Html): Document                    = Jsoup.parse(html.toString())
+  implicit protected def htmlBodyOf(page: String): Document                  = Jsoup.parse(page)
+  implicit protected def htmlBodyOf(result: Future[Result]): Document        = htmlBodyOf(contentAsString(result))
+
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/config/ErrorHandlerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/config/ErrorHandlerSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config
+
+import play.api.test.Helpers.stubMessagesApi
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitViewSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.ErrorTemplate
+
+class ErrorHandlerSpec extends UnitViewSpec {
+
+  val errorPage            = instanceOf[ErrorTemplate]
+  val appConfig: AppConfig = instanceOf[AppConfig]
+
+  val errorHandler = new ErrorHandler(errorPage, stubMessagesApi())(appConfig)
+
+  "ErrorHandler" should {
+
+    "render standardErrorTemplate" in {
+
+      val result = errorHandler.standardErrorTemplate("some title", "some heading", "some message")(request).body
+
+      result must include("some title")
+      result must include("some heading")
+      result must include("some message")
+    }
+  }
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/ControllerSpec.scala
@@ -16,19 +16,14 @@
 
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
 
-import javax.inject.{Inject, Singleton}
-import play.api.i18n.I18nSupport
-import play.api.mvc._
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
-import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import org.scalatest.BeforeAndAfterEach
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.AnyContentAsEmpty
+import play.api.test.FakeRequest
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.FakeIdentifierActions
 
-@Singleton
-class StartController @Inject() (mcc: MessagesControllerComponents, identify: IdentifierAction, startPage: StartPage)
-    extends FrontendController(mcc) with I18nSupport {
+trait ControllerSpec extends UnitSpec with MockitoSugar with FakeIdentifierActions with BeforeAndAfterEach {
 
-  val onPageLoad: Action[AnyContent] = identify { implicit request =>
-    Ok(startPage())
-  }
-
+  val fakeGetRequest: FakeRequest[AnyContentAsEmpty.type] = FakeRequest("GET", "/")
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/SessionExpiredControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/SessionExpiredControllerSpec.scala
@@ -21,13 +21,12 @@ import org.mockito.Mockito.{reset, when}
 import play.api.http.Status
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.SessionExpiredPage
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class StartControllerSpec extends ControllerSpec {
+class SessionExpiredControllerSpec extends ControllerSpec {
 
-  val page: StartPage = mock[StartPage]
+  val page: SessionExpiredPage = mock[SessionExpiredPage]
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -39,19 +38,13 @@ class StartControllerSpec extends ControllerSpec {
     super.afterEach()
   }
 
-  private def controller(identifyAction: IdentifierAction) =
-    new StartController(stubMessagesControllerComponents(), identifyAction, page)
+  private val controller = new SessionExpiredController(stubMessagesControllerComponents(), page)
 
   "GET" should {
-    "return OK when user is authorised" in {
-      val result = controller(fakeAuthorisedIdentifierAction).onPageLoad(fakeGetRequest)
+    "return OK" in {
+      val result = controller.onPageLoad(fakeGetRequest)
       status(result) mustBe Status.OK
     }
 
-    "redirect when user is unauthorised" in {
-      val result = controller(fakeUnauthorisedIdentifierAction).onPageLoad(fakeGetRequest)
-      status(result) mustBe Status.SEE_OTHER
-      redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
-    }
   }
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/SessionExpiredControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/SessionExpiredControllerSpec.scala
@@ -21,6 +21,7 @@ import org.mockito.Mockito.{reset, when}
 import play.api.http.Status
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.ControllerSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.SessionExpiredPage
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartControllerSpec.scala
@@ -21,6 +21,7 @@ import org.mockito.Mockito.{reset, when}
 import play.api.http.Status
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.ControllerSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartControllerSpec.scala
@@ -26,29 +26,31 @@ import play.api.{Configuration, Environment}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.HelloWorldPage
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
 
-class HelloWorldControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
+class StartControllerSpec extends AnyWordSpec with Matchers with GuiceOneAppPerSuite {
   private val fakeRequest = FakeRequest("GET", "/")
 
   private val env           = Environment.simple()
   private val configuration = Configuration.load(env)
 
   private val serviceConfig = new ServicesConfig(configuration)
-  private val appConfig     = new AppConfig(configuration, serviceConfig)
 
-  val helloWorldPage: HelloWorldPage = app.injector.instanceOf[HelloWorldPage]
+  val helloWorldPage: StartPage = app.injector.instanceOf[StartPage]
 
-  private val controller = new HelloWorldController(appConfig, stubMessagesControllerComponents(), helloWorldPage)
+  val identifierAction: IdentifierAction = app.injector.instanceOf[IdentifierAction]
+
+  private val controller = new StartController(stubMessagesControllerComponents(), identifierAction, helloWorldPage)
 
   "GET /" should {
     "return 200" in {
-      val result = controller.helloWorld(fakeRequest)
+      val result = controller.onPageLoad(fakeRequest)
       status(result) shouldBe Status.OK
     }
 
     "return HTML" in {
-      val result = controller.helloWorld(fakeRequest)
+      val result = controller.onPageLoad(fakeRequest)
       contentType(result) shouldBe Some("text/html")
       charset(result) shouldBe Some("utf-8")
     }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/UnauthorisedControllerSpec.scala
@@ -21,13 +21,12 @@ import org.mockito.Mockito.{reset, when}
 import play.api.http.Status
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.{SessionExpiredPage, UnauthorisedPage}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
-class StartControllerSpec extends ControllerSpec {
+class UnauthorisedControllerSpec extends ControllerSpec {
 
-  val page: StartPage = mock[StartPage]
+  val page: UnauthorisedPage = mock[UnauthorisedPage]
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -39,19 +38,13 @@ class StartControllerSpec extends ControllerSpec {
     super.afterEach()
   }
 
-  private def controller(identifyAction: IdentifierAction) =
-    new StartController(stubMessagesControllerComponents(), identifyAction, page)
+  private val controller = new UnauthorisedController(stubMessagesControllerComponents(), page)
 
   "GET" should {
-    "return OK when user is authorised" in {
-      val result = controller(fakeAuthorisedIdentifierAction).onPageLoad(fakeGetRequest)
+    "return OK" in {
+      val result = controller.onPageLoad(fakeGetRequest)
       status(result) mustBe Status.OK
     }
 
-    "redirect when user is unauthorised" in {
-      val result = controller(fakeUnauthorisedIdentifierAction).onPageLoad(fakeGetRequest)
-      status(result) mustBe Status.SEE_OTHER
-      redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad().url)
-    }
   }
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/UnauthorisedControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/UnauthorisedControllerSpec.scala
@@ -21,6 +21,7 @@ import org.mockito.Mockito.{reset, when}
 import play.api.http.Status
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.ControllerSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.{SessionExpiredPage, UnauthorisedPage}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/AuthenticatedIdentifierActionSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/AuthenticatedIdentifierActionSpec.scala
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions
+
+import org.scalatestplus.mockito.MockitoSugar
+import play.api.mvc.{BodyParsers, Result, Results}
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{redirectLocation, _}
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.utils.Injector
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class AuthActionSpec extends UnitSpec with MockitoSugar with Injector {
+
+  val appConfig: AppConfig        = instanceOf[AppConfig]
+  val parser: BodyParsers.Default = instanceOf[BodyParsers.Default]
+  val fakeRequest                 = FakeRequest()
+
+  class Harness(action: IdentifierAction) {
+    def onPageLoad() = action(request => Results.Ok)
+  }
+
+  "AuthenticatedIdentifierAction" when {
+
+    "the user hasn't logged in" must {
+      "redirect the user to log in " in {
+        val result: Future[Result] = handleAuthError(MissingBearerToken())
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).get must beTheLoginPage
+      }
+    }
+
+    "the user's session has expired" must {
+      "redirect the user to log in " in {
+        val result: Future[Result] = handleAuthError(BearerTokenExpired())
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).get must beTheLoginPage
+      }
+    }
+
+    "the user's credentials are invalid" must {
+      "redirect the user to log in " in {
+        val result: Future[Result] = handleAuthError(InvalidBearerToken())
+
+        status(result) mustBe SEE_OTHER
+        redirectLocation(result).get must beTheLoginPage
+      }
+    }
+  }
+
+  private def beTheLoginPage =
+    startWith(appConfig.loginUrl)
+
+  private def handleAuthError(exc: AuthorisationException): Future[Result] = {
+    val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(exc), appConfig, parser)
+    val controller = new Harness(authAction)
+    controller.onPageLoad()(fakeRequest)
+  }
+
+}
+
+class FakeFailingAuthConnector(exceptionToReturn: Throwable) extends AuthConnector {
+
+  override def authorise[A](predicate: Predicate, retrieval: Retrieval[A])(implicit
+    hc: HeaderCarrier,
+    ec: ExecutionContext
+  ): Future[A] =
+    Future.failed(exceptionToReturn)
+
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/FakeIdentifierAction.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/FakeIdentifierAction.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions
+
+import javax.inject.Inject
+import play.api.mvc._
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests.IdentifierRequest
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers) extends IdentifierAction {
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
+    block(IdentifierRequest(request, "id"))
+
+  override def parser: BodyParser[AnyContent] =
+    bodyParsers.default
+
+  override protected def executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/FakeIdentifierActions.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/actions/FakeIdentifierActions.scala
@@ -17,15 +17,37 @@
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions
 
 import javax.inject.Inject
+import play.api.mvc.Results.Redirect
 import play.api.mvc._
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.routes
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests.IdentifierRequest
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.utils.Injector
 
 import scala.concurrent.{ExecutionContext, Future}
+
+trait FakeIdentifierActions extends Injector {
+
+  val fakeAuthorisedIdentifierAction   = instanceOf[FakeIdentifierAction]
+  val fakeUnauthorisedIdentifierAction = instanceOf[FakeUnauthorisedIdentiferAction]
+}
 
 class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers) extends IdentifierAction {
 
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
     block(IdentifierRequest(request, "id"))
+
+  override def parser: BodyParser[AnyContent] =
+    bodyParsers.default
+
+  override protected def executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+
+}
+
+class FakeUnauthorisedIdentiferAction @Inject() (bodyParsers: PlayBodyParsers) extends IdentifierAction {
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] =
+    Future.successful(Redirect(routes.UnauthorisedController.onPageLoad()))
 
   override def parser: BodyParser[AnyContent] =
     bodyParsers.default

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/utils/Injector.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/utils/Injector.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.utils
+
+import com.codahale.metrics.SharedMetricRegistries
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.reflect.ClassTag
+
+trait Injector {
+
+  /**
+    * Clearing shared metrics registries to avoid `A metric named jvm.attribute.vendor already exists` error.
+    *
+   * It appears very often with places with injector. This is enough solution for this problem.
+    *
+   * Reference and other solutions: https://github.com/kenshoo/metrics-play/issues/74
+    */
+  SharedMetricRegistries.clear()
+  private val injector                                           = GuiceApplicationBuilder().injector()
+  def instanceOf[T <: AnyRef](implicit classTag: ClassTag[T]): T = injector.instanceOf[T]
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/ErrorTemplateViewSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/ErrorTemplateViewSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views
+
+import play.twirl.api.Html
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitViewSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.{ErrorTemplate, StartPage}
+
+class ErrorTemplateViewSpec extends UnitViewSpec {
+
+  private val page = instanceOf[ErrorTemplate]
+
+  private val view: Html = page("some title", "some heading", "some message")
+
+  "StartPage" should {
+
+    "have correct title" in {
+      view.title() mustBe "some title"
+    }
+
+    "have correct heading" in {
+      view.getElementsByTag("h1").text() mustBe "some heading"
+    }
+
+    "have correct message" in {
+      view.getElementsByClass("govuk-body").text() mustBe "some message"
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPageViewSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/SessionExpiredPageViewSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views
+
+import play.twirl.api.Html
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitViewSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.SessionExpiredPage
+
+class SessionExpiredPageViewSpec extends UnitViewSpec {
+
+  private val page = instanceOf[SessionExpiredPage]
+
+  private val view: Html = page()
+
+  "SessionExpiredPage" should {
+
+    "have correct title" in {
+      view.title() mustBe messages("session_expired.title")
+    }
+
+    "have correct heading" in {
+      view.getElementsByTag("h1").text() mustBe messages("session_expired.title")
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/StartPageViewSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/StartPageViewSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views
+
+import play.twirl.api.Html
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitViewSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.StartPage
+
+class StartPageViewSpec extends UnitViewSpec {
+
+  private val page = instanceOf[StartPage]
+
+  private val view: Html = page()
+
+  "StartPage" should {
+
+    "have correct title" in {
+      view.title() mustBe messages("start_page.title")
+    }
+
+    "have correct heading" in {
+      view.getElementsByTag("h1").text() mustBe messages("start_page.title")
+    }
+
+  }
+}

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/UnauthorisedPageViewSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/UnauthorisedPageViewSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views
+
+import play.twirl.api.Html
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitViewSpec
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.UnauthorisedPage
+
+class UnauthorisedPageViewSpec extends UnitViewSpec {
+
+  private val page = instanceOf[UnauthorisedPage]
+
+  private val view: Html = page()
+
+  "UnauthorisedPage" should {
+
+    "have correct title" in {
+      view.title() mustBe messages("unauthorised.title")
+    }
+
+    "have correct heading" in {
+      view.getElementsByTag("h1").text() mustBe messages("unauthorised.title")
+    }
+
+  }
+}


### PR DESCRIPTION
Applied an 'IdentifierAction' filter to the default end-point (was /hello-world) which ensures that the user is logged in via GG
This approach was taken from NDRC which in turn was generated using the Jenkins scafford job.