### PR TITLE
NF-168 - make BankDetails non-optional 

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/Claim.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/Claim.scala
@@ -27,7 +27,7 @@ case class Claim(
   claimType: ClaimType,
   uploads: Seq[UploadedFile],
   reclaimDutyTypes: Set[ReclaimDutyType],
-  bankDetails: Option[BankDetails],
+  bankDetails: BankDetails,
   entryDetails: EntryDetails
 )
 
@@ -42,7 +42,7 @@ object Claim {
       claimType = userAnswers.claimType.getOrElse(missing(ClaimTypePage)),
       uploads = userAnswers.uploads.getOrElse(missing(UploadPage)),
       reclaimDutyTypes = userAnswers.reclaimDutyTypes.getOrElse(missing(ReclaimDutyTypePage)),
-      bankDetails = userAnswers.bankDetails,
+      bankDetails = userAnswers.bankDetails.getOrElse(missing(BankDetailsPage)),
       entryDetails = userAnswers.entryDetails.getOrElse(missing(EntryDetailsPage))
     )
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequest.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequest.scala
@@ -61,7 +61,7 @@ object EISCreateCaseRequest {
         EntryDate = entryDataFormatter.format(claim.entryDetails.entryDate),
         // TODO - remove hard-coded values for paid and due amounts
         DutyDetails = claim.reclaimDutyTypes.map(value => DutyDetail(value.toString, "0", "0")).toSeq,
-        PaymentDetails = claim.bankDetails.map(PaymentDetails(_)),
+        PaymentDetails = Some(PaymentDetails(claim.bankDetails)),
         FirstName = claim.contactDetails.firstName,
         LastName = claim.contactDetails.lastName
       )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/makeclaim/CheckYourAnswersPage.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/makeclaim/CheckYourAnswersPage.scala.html
@@ -134,22 +134,20 @@
         id = "payment_section",
         heading = Some(messages("check_answers.payment.title")),
         summaryListRows = Seq(
-            claim.bankDetails.map(bankDetails =>
-                SummaryListRow(
-                    classes = "bank_details_type_row",
-                    key = Key(
-                        content = Text(messages("check_answers.payment.bankDetails"))
-                    ),
-                    value = Value(
-                        content = HtmlContent(Seq(
-                            bankDetails.accountName,
-                            bankDetails.sortCode,
-                            bankDetails.accountNumber
-                        ).mkString("<br>"))
-                    ),
-                    actions = None
-                )
-            )
+            Some(SummaryListRow(
+                classes = "bank_details_type_row",
+                key = Key(
+                    content = Text(messages("check_answers.payment.bankDetails"))
+                ),
+                value = Value(
+                    content = HtmlContent(Seq(
+                        claim.bankDetails.accountName,
+                        claim.bankDetails.sortCode,
+                        claim.bankDetails.accountNumber
+                    ).mkString("<br>"))
+                ),
+                actions = None
+            ))
         )
     )
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequestSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequestSpec.scala
@@ -37,11 +37,11 @@ class EISCreateCaseRequestSpec extends UnitSpec {
     claimType = AntiDumping,
     uploads = Seq.empty,
     reclaimDutyTypes = Set(Vat),
-    bankDetails = Some(BankDetails("account name", "001122", "12345678")),
+    bankDetails = BankDetails("account name", "001122", "12345678"),
     entryDetails = EntryDetails("012", "123456Q", LocalDate.of(2020, 12, 31))
   )
 
-  val content = EISCreateCaseRequest.Content(
+  val content: EISCreateCaseRequest.Content = EISCreateCaseRequest.Content(
     ClaimType = "Anti-Dumping",
     ImporterDetails = ImporterDetails(
       "Import Co Ltd",


### PR DESCRIPTION
Now that repayment method is always BACS, `BankDetails` should not be optional on the `Claim` model.