### PR TITLE
BAU - refactor Claim to extract all importer information

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/ImporterBeingRepresentedDetails.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/ImporterBeingRepresentedDetails.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class ImporterBeingRepresentedDetails(
+  repayTo: RepayTo,
+  eoriNumber: Option[EoriNumber],
+  contactDetails: ImporterContactDetails
+)
+
+object ImporterBeingRepresentedDetails {
+  implicit val format: OFormat[ImporterBeingRepresentedDetails] = Json.format[ImporterBeingRepresentedDetails]
+}

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequest.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequest.scala
@@ -69,7 +69,7 @@ object EISCreateCaseRequest {
         EntryNumber = claim.entryDetails.entryNumber,
         EntryDate = eisDateFormatter.format(claim.entryDetails.entryDate),
         DutyDetails = claim.reclaimDutyPayments.map(entry => DutyDetail(entry._1, entry._2)).toSeq,
-        PayTo = claim.repayTo.getOrElse(Importer).toString,
+        PayTo = claim.importerBeingRepresentedDetails.map(_.repayTo).getOrElse(Importer).toString,
         PaymentDetails = Some(PaymentDetails(claim.bankDetails)),
         ItemNumber = claim.itemNumbers.numbers,
         ClaimReason = claim.claimReason.reason,

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/ImporterDetails.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/ImporterDetails.scala
@@ -22,8 +22,7 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{
   Claim,
   ContactDetails,
-  EoriNumber,
-  ImporterContactDetails,
+  ImporterBeingRepresentedDetails,
   Address => UkAddress
 }
 
@@ -35,8 +34,9 @@ object ImporterDetails {
   def forClaim(claim: Claim): ImporterDetails = claim.representationType match {
     case Representative =>
       forRepresentativeApplicant(
-        claim.importerEoriNumber,
-        claim.importerContactDetails.getOrElse(throw new MissingUserAnswersException("Missing ImporterContactDetails"))
+        claim.importerBeingRepresentedDetails.getOrElse(
+          throw new MissingUserAnswersException("Missing ImporterBeingRepresentedDetails")
+        )
       )
     case Importer => forImporterApplicant(claim.contactDetails, claim.claimantAddress)
   }
@@ -56,21 +56,18 @@ object ImporterDetails {
       )
     )
 
-  def forRepresentativeApplicant(
-    importerEoriNumber: Option[EoriNumber],
-    importer: ImporterContactDetails
-  ): ImporterDetails =
+  def forRepresentativeApplicant(importer: ImporterBeingRepresentedDetails): ImporterDetails =
     new ImporterDetails(
-      EORI = importerEoriNumber.map(_.number),
-      Name = importer.name,
+      EORI = importer.eoriNumber.map(_.number),
+      Name = importer.contactDetails.name,
       Address = Address(
-        AddressLine1 = importer.addressLine1,
-        AddressLine2 = importer.addressLine2,
-        City = importer.city,
-        PostalCode = importer.postCode,
+        AddressLine1 = importer.contactDetails.addressLine1,
+        AddressLine2 = importer.contactDetails.addressLine2,
+        City = importer.contactDetails.city,
+        PostalCode = importer.contactDetails.postCode,
         CountryCode = "GB",
-        EmailAddress = importer.emailAddress,
-        TelephoneNumber = importer.telephoneNumber
+        EmailAddress = importer.contactDetails.emailAddress,
+        TelephoneNumber = importer.contactDetails.telephoneNumber
       )
     )
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/makeclaim/CheckYourAnswersView.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/makeclaim/CheckYourAnswersView.scala.html
@@ -179,8 +179,8 @@
         )
     )
 
-    @if(claim.representationType == RepresentationType.Representative) {
-        @summaryList(
+    @claim.importerBeingRepresentedDetails.map(importer =>
+        summaryList(
             id = "importer_section",
             heading = Some(messages("check_answers.importer.title")),
             summaryListRows = Seq(
@@ -191,12 +191,12 @@
                             content = Text(messages("check_answers.importer.hasEori"))
                         ),
                         value = Value(
-                            content = Text(MessageKey.apply("check_answers.importer.hasEori", claim.importerEoriNumber.isDefined.toString))
+                            content = Text(MessageKey.apply("check_answers.importer.hasEori", importer.eoriNumber.isDefined.toString))
                         ),
                         actions = None
                     )
                 ),
-                claim.importerEoriNumber.map(eori =>
+                importer.eoriNumber.map(eori =>
                     SummaryListRow(
                         classes = "importer_eori_row",
                         key = Key(
@@ -208,7 +208,7 @@
                         actions = None
                     )
                 ),
-                claim.importerContactDetails.map(contactDetails =>
+                Some(
                     SummaryListRow(
                         classes = "importer_contact_details_row",
                         key = Key(
@@ -216,13 +216,13 @@
                         ),
                         value = Value(
                             content = HtmlContent(Seq(
-                                Some(contactDetails.name),
-                                Some(contactDetails.addressLine1),
-                                contactDetails.addressLine2,
-                                Some(contactDetails.city),
-                                Some(contactDetails.postCode),
-                                Some(contactDetails.emailAddress),
-                                Some(contactDetails.telephoneNumber)
+                                Some(importer.contactDetails.name),
+                                Some(importer.contactDetails.addressLine1),
+                                importer.contactDetails.addressLine2,
+                                Some(importer.contactDetails.city),
+                                Some(importer.contactDetails.postCode),
+                                Some(importer.contactDetails.emailAddress),
+                                Some(importer.contactDetails.telephoneNumber)
                             ).flatten.mkString("<br>"))
                         ),
                         actions = None
@@ -230,13 +230,14 @@
                 )
             )
         )
-    }
+
+    )
 
     @summaryList(
         id = "payment_section",
         heading = Some(messages("check_answers.payment.title")),
         summaryListRows = Seq(
-            claim.repayTo.map(payTo =>
+            claim.importerBeingRepresentedDetails.map(_.repayTo).map(payTo =>
                 SummaryListRow(
                     classes = "pay_to_row",
                     key = Key(

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/ClaimSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/ClaimSpec.scala
@@ -67,12 +67,12 @@ class ClaimSpec extends UnitSpec with TestData {
       Claim(completeAnswers).repaymentTotal mustBe expected
     }
 
-    "ignore 'repay to' answer when representation type is 'importer'" in {
+    "ignore 'importer being represented' answers when representation type is 'importer'" in {
       val answersWithRepayTo = completeAnswers.copy(
         representationType = Some(RepresentationType.Importer),
         repayTo = Some(RepayTo.Representative)
       )
-      Claim(answersWithRepayTo).repayTo mustBe None
+      Claim(answersWithRepayTo).importerBeingRepresentedDetails mustBe None
     }
   }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequestSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/EISCreateCaseRequestSpec.scala
@@ -21,20 +21,8 @@ import java.time.LocalDate
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.UnitSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ClaimType.AntiDumping
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.{Customs, Other, Vat}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{
-  BankDetails,
-  Claim,
-  ClaimReason,
-  ContactDetails,
-  DutyPaid,
-  EntryDetails,
-  EoriNumber,
-  ImporterContactDetails,
-  ItemNumbers,
-  RepayTo,
-  RepresentationType,
-  Address => UkAddress
-}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models._
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{Address => UkAddress}
 
 class EISCreateCaseRequestSpec extends UnitSpec {
 
@@ -60,20 +48,23 @@ class EISCreateCaseRequestSpec extends UnitSpec {
     uploads = Seq.empty,
     reclaimDutyPayments =
       Map(Customs -> DutyPaid("100", "80"), Vat -> DutyPaid("200.10", "175"), Other -> DutyPaid("10", "5.50")),
-    repayTo = Some(RepayTo.Representative),
-    bankDetails = BankDetails("account name", "001122", "12345678"),
-    importerEoriNumber = Some(EoriNumber("GB098765432123")),
-    importerContactDetails = Some(
-      ImporterContactDetails(
-        "Import Co Ltd",
-        "Importer Address Line 1",
-        Some("Importer Address Line 2"),
-        "Importer City",
-        "IM12CD",
-        "contact@importer.com",
-        "99999999999"
+    importerBeingRepresentedDetails = Some(
+      ImporterBeingRepresentedDetails(
+        repayTo = RepayTo.Representative,
+        eoriNumber = Some(EoriNumber("GB098765432123")),
+        contactDetails =
+          ImporterContactDetails(
+            "Import Co Ltd",
+            "Importer Address Line 1",
+            Some("Importer Address Line 2"),
+            "Importer City",
+            "IM12CD",
+            "contact@importer.com",
+            "99999999999"
+          )
       )
     ),
+    bankDetails = BankDetails("account name", "001122", "12345678"),
     entryDetails = EntryDetails("012", "123456Q", LocalDate.of(2020, 12, 31)),
     itemNumbers = ItemNumbers("1, 2, 5-10"),
     submissionDate = LocalDate.of(2021, 1, 31)
@@ -125,10 +116,8 @@ class EISCreateCaseRequestSpec extends UnitSpec {
     uploads = Seq.empty,
     reclaimDutyPayments =
       Map(Customs -> DutyPaid("100", "80"), Vat -> DutyPaid("200.10", "175"), Other -> DutyPaid("10", "5.50")),
-    repayTo = None,
+    importerBeingRepresentedDetails = None,
     bankDetails = BankDetails("account name", "001122", "12345678"),
-    importerEoriNumber = None,
-    importerContactDetails = None,
     entryDetails = EntryDetails("012", "123456Q", LocalDate.of(2020, 12, 31)),
     itemNumbers = ItemNumbers("1, 2, 5-10"),
     submissionDate = LocalDate.of(2021, 1, 31)

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/makeclaim/CheckYourAnswersViewSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/makeclaim/CheckYourAnswersViewSpec.scala
@@ -83,7 +83,7 @@ class CheckYourAnswersViewSpec extends UnitViewSpec with TestData {
     }
 
     "not have importer details when claimant is importer" in {
-      view(completeClaim.copy(representationType = RepresentationType.Importer)).getElementById(
+      view(completeClaim.copy(importerBeingRepresentedDetails = None)).getElementById(
         "importer_section"
       ) must notBePresent
     }
@@ -105,7 +105,8 @@ class CheckYourAnswersViewSpec extends UnitViewSpec with TestData {
       }
 
       "does not contains Eori number when importer does not have EORI" in {
-        val importerSection = view(completeClaim.copy(importerEoriNumber = None)).getElementById("importer_section")
+        val importerSection =
+          view(Claim(completeAnswers.copy(importerHasEori = Some(false)))).getElementById("importer_section")
 
         val eoriRow = importerSection.getElementsByClass("importer_eori_row")
         eoriRow must beEmpty


### PR DESCRIPTION
All information that is only relevant for a representative making a claim is moved to `ImporterBeingRepresentedDetails`