### PR TITLE
BAU - refactor UserAnswers in preparation for update-claim journey

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/KeepAliveController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/KeepAliveController.scala
@@ -34,7 +34,7 @@ class KeepAliveController @Inject() (
     extends FrontendController(mcc) with I18nSupport {
 
   val keepAlive: Action[AnyContent] = identify.async { implicit request =>
-    cacheData.updateAnswers(answers => answers) map { _ =>
+    cacheData.updateCreateAnswers(answers => answers) map { _ =>
       Ok("Ok")
     }
   }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/Navigation.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/Navigation.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
 
 import play.api.mvc.Call
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.UserAnswers
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.CreateAnswers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.navigation.Navigator
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.Page
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.viewmodels.NavigatorBack
@@ -26,7 +26,7 @@ trait Navigation {
   val navigator: Navigator
   val page: Page
 
-  def nextPage: UserAnswers => Call = navigator.nextPage(page, _)
+  def nextPage: CreateAnswers => Call = navigator.nextPage(page, _)
 
-  def backLink: UserAnswers => NavigatorBack = navigator.previousPage(page, _)
+  def backLink: CreateAnswers => NavigatorBack = navigator.previousPage(page, _)
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartController.scala
@@ -20,7 +20,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.UserAnswers
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.CreateAnswers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.navigation.Navigator
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.FirstPage
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -29,7 +29,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 class StartController @Inject() (mcc: MessagesControllerComponents, identify: IdentifierAction, navigator: Navigator)
     extends FrontendController(mcc) with I18nSupport {
 
-  private val noAnswers = UserAnswers()
+  private val noAnswers = CreateAnswers()
 
   val start: Action[AnyContent] = identify { _ =>
     Redirect(navigator.nextPage(FirstPage, noAnswers))

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/AddressController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/AddressController.scala
@@ -46,7 +46,7 @@ class AddressController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.claimantAddress.fold(form)(form.fill)
       Ok(addressView(preparedForm, backLink(answers)))
     }
@@ -54,9 +54,10 @@ class AddressController @Inject() (
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
-      formWithErrors => data.getAnswers map { answers => BadRequest(addressView(formWithErrors, backLink(answers))) },
+      formWithErrors =>
+        data.getCreateAnswers map { answers => BadRequest(addressView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(claimantAddress = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(claimantAddress = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/CheckYourAnswersController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/CheckYourAnswersController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.Navigation
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.Claim
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingUserAnswersException
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingAnswersException
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.navigation.Navigator
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.{CheckYourAnswersPage, Page}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.services.{CacheDataService, CreateClaimService}
@@ -46,26 +46,26 @@ class CheckYourAnswersController @Inject() (
   override val page: Page = CheckYourAnswersPage
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       Ok(checkYourAnswersView(Claim(answers), backLink(answers)))
     } recover {
-      case _: MissingUserAnswersException =>
+      case _: MissingAnswersException =>
         Redirect(controllers.routes.StartController.start())
     }
   }
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers flatMap { answers =>
+    data.getCreateAnswers flatMap { answers =>
       val claim = Claim(answers)
       service.submitClaim(claim) flatMap {
         case response if response.error.isDefined => throw new Exception(s"Error - ${response.error}")
         case response =>
-          data.updateResponse(response) map {
+          data.updateCreateResponse(response) map {
             _ => Redirect(nextPage(answers))
           }
       }
     } recover {
-      case _: MissingUserAnswersException =>
+      case _: MissingAnswersException =>
         Redirect(controllers.routes.StartController.start())
     }
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimReasonController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimReasonController.scala
@@ -46,7 +46,7 @@ class ClaimReasonController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.claimReason.fold(form)(form.fill)
       Ok(claimReasonView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class ClaimReasonController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(claimReasonView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(claimReasonView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(claimReason = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(claimReason = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimTypeController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimTypeController.scala
@@ -46,7 +46,7 @@ class ClaimTypeController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.claimType.fold(form)(form.fill)
       Ok(claimTypeView(preparedForm, backLink(answers)))
     }
@@ -54,9 +54,10 @@ class ClaimTypeController @Inject() (
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
-      formWithErrors => data.getAnswers map { answers => BadRequest(claimTypeView(formWithErrors, backLink(answers))) },
+      formWithErrors =>
+        data.getCreateAnswers map { answers => BadRequest(claimTypeView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(claimType = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(claimType = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ContactDetailsController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ContactDetailsController.scala
@@ -46,7 +46,7 @@ class ContactDetailsController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.contactDetails.fold(form)(form.fill)
       Ok(contactDetailsView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class ContactDetailsController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(contactDetailsView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(contactDetailsView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(contactDetails = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(contactDetails = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/DutyRepaymentController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/DutyRepaymentController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.action
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.DutyPaidFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.{Customs, Other, Vat}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests.IdentifierRequest
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{DutyPaid, ReclaimDutyType, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, DutyPaid, ReclaimDutyType}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.navigation.Navigator
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.services.CacheDataService
@@ -51,7 +51,7 @@ class DutyRepaymentController @Inject() (
   def onPageLoadOtherDuty(): Action[AnyContent]   = onPageLoad(Other)
 
   private def onPageLoad(dutyType: ReclaimDutyType): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.reclaimDutyPayments.get(dutyType).fold(form)(form.fill)
       Ok(page(dutyType, preparedForm, answers))
     }
@@ -63,9 +63,9 @@ class DutyRepaymentController @Inject() (
 
   private def onSubmit(dutyType: ReclaimDutyType): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
-      formWithErrors => data.getAnswers map { answers => BadRequest(page(dutyType, formWithErrors, answers)) },
+      formWithErrors => data.getCreateAnswers map { answers => BadRequest(page(dutyType, formWithErrors, answers)) },
       value =>
-        data.updateAnswers(
+        data.updateCreateAnswers(
           answers => answers.copy(reclaimDutyPayments = answers.reclaimDutyPayments.updated(dutyType, value))
         ) map {
           updatedAnswers => Redirect(navigator.nextPage(currentPage(dutyType), updatedAnswers))
@@ -80,7 +80,7 @@ class DutyRepaymentController @Inject() (
     case _       => FirstPage
   }
 
-  private def page(dutyType: ReclaimDutyType, form: Form[DutyPaid], answers: UserAnswers)(implicit
+  private def page(dutyType: ReclaimDutyType, form: Form[DutyPaid], answers: CreateAnswers)(implicit
     request: IdentifierRequest[_]
   ) = {
     val backLink = navigator.previousPage(currentPage(dutyType), answers)

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/EntryDetailsController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/EntryDetailsController.scala
@@ -46,7 +46,7 @@ class EntryDetailsController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.entryDetails.fold(form)(form.fill)
       Ok(entryDetailsView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class EntryDetailsController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(entryDetailsView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(entryDetailsView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(entryDetails = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(entryDetails = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterDetailsController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterDetailsController.scala
@@ -46,7 +46,7 @@ class ImporterDetailsController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.importerContactDetails.fold(form)(form.fill)
       Ok(detailsView(preparedForm, backLink(answers)))
     }
@@ -54,9 +54,10 @@ class ImporterDetailsController @Inject() (
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
-      formWithErrors => data.getAnswers map { answers => BadRequest(detailsView(formWithErrors, backLink(answers))) },
+      formWithErrors =>
+        data.getCreateAnswers map { answers => BadRequest(detailsView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(importerContactDetails = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(importerContactDetails = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterEoriNumberController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterEoriNumberController.scala
@@ -46,7 +46,7 @@ class ImporterEoriNumberController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.importerEori.fold(form)(form.fill)
       Ok(eoriNumberView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class ImporterEoriNumberController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(eoriNumberView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(eoriNumberView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(importerEori = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(importerEori = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterHasEoriController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterHasEoriController.scala
@@ -46,7 +46,7 @@ class ImporterHasEoriController @Inject() (
   private val form = formProvider("importer.has.eori.required")
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.importerHasEori.fold(form)(form.fill)
       Ok(importerHasEoriView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class ImporterHasEoriController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(importerHasEoriView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(importerHasEoriView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(importerHasEori = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(importerHasEori = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ItemNumbersController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ItemNumbersController.scala
@@ -46,7 +46,7 @@ class ItemNumbersController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.itemNumbers.fold(form)(form.fill)
       Ok(itemNumbersView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class ItemNumbersController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(itemNumbersView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(itemNumbersView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(itemNumbers = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(itemNumbers = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ReclaimDutyTypeController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ReclaimDutyTypeController.scala
@@ -46,7 +46,7 @@ class ReclaimDutyTypeController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = form.fill(answers.reclaimDutyTypes)
       Ok(reclaimDutyTypeView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class ReclaimDutyTypeController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(reclaimDutyTypeView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(reclaimDutyTypeView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(reclaimDutyTypes = value)) map {
+        data.updateCreateAnswers(answers => answers.copy(reclaimDutyTypes = value)) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepayToController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepayToController.scala
@@ -46,7 +46,7 @@ class RepayToController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.repayTo.fold(form)(form.fill)
       Ok(representationTypeView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class RepayToController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(representationTypeView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(representationTypeView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(repayTo = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(repayTo = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepresentationTypeController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepresentationTypeController.scala
@@ -46,7 +46,7 @@ class RepresentationTypeController @Inject() (
   private val form = formProvider()
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       val preparedForm = answers.representationType.fold(form)(form.fill)
       Ok(representationTypeView(preparedForm, backLink(answers)))
     }
@@ -55,9 +55,9 @@ class RepresentationTypeController @Inject() (
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
     form.bindFromRequest().fold(
       formWithErrors =>
-        data.getAnswers map { answers => BadRequest(representationTypeView(formWithErrors, backLink(answers))) },
+        data.getCreateAnswers map { answers => BadRequest(representationTypeView(formWithErrors, backLink(answers))) },
       value =>
-        data.updateAnswers(answers => answers.copy(representationType = Some(value))) map {
+        data.updateCreateAnswers(answers => answers.copy(representationType = Some(value))) map {
           updatedAnswers => Redirect(nextPage(updatedAnswers))
         }
     )

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/UploadFormSummaryController.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/UploadFormSummaryController.scala
@@ -23,7 +23,7 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.Navigation
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.YesNoFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.UserAnswers
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.CreateAnswers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.navigation.Navigator
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.{Page, UploadSummaryPage}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.services.CacheDataService
@@ -48,7 +48,7 @@ class UploadFormSummaryController @Inject() (
   private val form = formProvider("upload_documents_summary.add.required")
 
   def onPageLoad(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers map { answers =>
+    data.getCreateAnswers map { answers =>
       answers.uploads match {
         case documents if documents.nonEmpty =>
           Ok(
@@ -65,12 +65,12 @@ class UploadFormSummaryController @Inject() (
   }
 
   def onSubmit(): Action[AnyContent] = identify.async { implicit request =>
-    data.getAnswers flatMap { answers =>
+    data.getCreateAnswers flatMap { answers =>
       form.bindFromRequest().fold(
         formWithErrors =>
           Future(BadRequest(summaryView(formWithErrors, answers.claimType, answers.uploads, backLink(answers)))),
         addAnother =>
-          data.updateAnswers(answers => answers.copy(uploadAnotherFile = Some(addAnother))) map {
+          data.updateCreateAnswers(answers => answers.copy(uploadAnotherFile = Some(addAnother))) map {
             _ =>
               if (addAnother)
                 Redirect(controllers.makeclaim.routes.UploadFormController.onPageLoad())
@@ -82,13 +82,13 @@ class UploadFormSummaryController @Inject() (
   }
 
   def onRemove(documentReference: String): Action[AnyContent] = identify.async { implicit request =>
-    data.updateAnswers(removeDocument(documentReference)) map { _ =>
+    data.updateCreateAnswers(removeDocument(documentReference)) map { _ =>
       Redirect(controllers.makeclaim.routes.UploadFormSummaryController.onPageLoad())
     }
   }
 
-  def removeDocument: String => UserAnswers => UserAnswers = (ref: String) =>
-    (userAnswers: UserAnswers) => {
+  def removeDocument: String => CreateAnswers => CreateAnswers = (ref: String) =>
+    (userAnswers: CreateAnswers) => {
       val remainingFiles = userAnswers.uploads.filterNot(_.upscanReference == ref)
       userAnswers.copy(uploads = remainingFiles)
     }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/CacheData.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/CacheData.scala
@@ -22,12 +22,13 @@ import play.api.libs.json.{Json, OFormat}
 
 final case class CacheData(
   id: String,
-  answers: UserAnswers = UserAnswers(),
+  createAnswers: Option[CreateAnswers] = None,
   createClaimResponse: Option[CreateClaimResponse] = None,
   lastUpdated: LocalDateTime = LocalDateTime.now
 ) {
 
   def claimReference: Option[String] = createClaimResponse.flatMap(_.result).map(_.caseReference)
+  def getCreateAnswers               = createAnswers.getOrElse(CreateAnswers())
 }
 
 object CacheData {

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/Claim.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/Claim.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models
 import java.time.LocalDate
 
 import play.api.Logger
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingUserAnswersException
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingAnswersException
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.upscan.UploadedFile
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages._
 
@@ -46,7 +46,7 @@ case class Claim(
 
 object Claim {
 
-  def apply(userAnswers: UserAnswers): Claim = {
+  def apply(userAnswers: CreateAnswers): Claim = {
     if (userAnswers.uploads.isEmpty) missing(UploadSummaryPage)
     if (userAnswers.reclaimDutyTypes.isEmpty) missing(ReclaimDutyTypePage)
     new Claim(
@@ -68,7 +68,7 @@ object Claim {
     )
   }
 
-  private def importerBeingRepresentedDetails(userAnswers: UserAnswers): Option[ImporterBeingRepresentedDetails] =
+  private def importerBeingRepresentedDetails(userAnswers: CreateAnswers): Option[ImporterBeingRepresentedDetails] =
     userAnswers.representationType match {
       case Some(RepresentationType.Importer) => None
       case Some(RepresentationType.Representative) =>
@@ -87,7 +87,7 @@ object Claim {
   private def missing(answer: Any) = {
     val message = s"Missing answer - $answer"
     Logger(this.getClass).warn(message)
-    throw new MissingUserAnswersException(message)
+    throw new MissingAnswersException(message)
   }
 
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/CreateAnswers.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/CreateAnswers.scala
@@ -20,7 +20,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.RepresentationType.Representative
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.upscan.UploadedFile
 
-final case class UserAnswers(
+final case class CreateAnswers(
   journeyId: JourneyId = JourneyId.generate,
   contactDetails: Option[ContactDetails] = None,
   claimantAddress: Option[Address] = None,
@@ -44,7 +44,7 @@ final case class UserAnswers(
   val doesImporterHaveEori: Boolean = importerHasEori.contains(true)
 }
 
-object UserAnswers {
+object CreateAnswers {
 
-  implicit val formats: OFormat[UserAnswers] = Json.format[UserAnswers]
+  implicit val formats: OFormat[CreateAnswers] = Json.format[CreateAnswers]
 }

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/ImporterDetails.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/eis/ImporterDetails.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.eis
 
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.RepresentationType.{Importer, Representative}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingUserAnswersException
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingAnswersException
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{
   Claim,
   ContactDetails,
@@ -35,7 +35,7 @@ object ImporterDetails {
     case Representative =>
       forRepresentativeApplicant(
         claim.importerBeingRepresentedDetails.getOrElse(
-          throw new MissingUserAnswersException("Missing ImporterBeingRepresentedDetails")
+          throw new MissingAnswersException("Missing ImporterBeingRepresentedDetails")
         )
       )
     case Importer => forImporterApplicant(claim.contactDetails, claim.claimantAddress)

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/exceptions/MissingAnswersException.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/exceptions/MissingAnswersException.scala
@@ -16,4 +16,4 @@
 
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions
 
-class MissingUserAnswersException(message: String) extends RuntimeException(message)
+class MissingAnswersException(message: String) extends RuntimeException(message)

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/navigation/Navigator.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/navigation/Navigator.scala
@@ -20,11 +20,11 @@ import javax.inject.{Inject, Singleton}
 import play.api.mvc.Call
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.makeclaim
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.{Customs, Other, Vat}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ReclaimDutyType, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, ReclaimDutyType}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.{Page, _}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.viewmodels.NavigatorBack
 
-protected case class P(page: Page, destination: () => Call, canAccessGiven: UserAnswers => Boolean)
+protected case class P(page: Page, destination: () => Call, canAccessGiven: CreateAnswers => Boolean)
 
 @Singleton
 class Navigator @Inject() () extends Conditions with Ordering {
@@ -54,34 +54,34 @@ class Navigator @Inject() () extends Conditions with Ordering {
 
   private val reversePageOrder = pageOrder.reverse
 
-  def nextPage(currentPage: Page, userAnswers: UserAnswers): Call =
+  def nextPage(currentPage: Page, userAnswers: CreateAnswers): Call =
     viewFor(pageOrder, nextPageFor(pageOrder, currentPage, userAnswers)).getOrElse(pageOrder.head.destination())
 
-  def previousPage(currentPage: Page, userAnswers: UserAnswers): NavigatorBack =
+  def previousPage(currentPage: Page, userAnswers: CreateAnswers): NavigatorBack =
     NavigatorBack(viewFor(pageOrder, nextPageFor(reversePageOrder, currentPage, userAnswers)))
 
 }
 
 protected trait Conditions {
-  protected val always: UserAnswers => Boolean = (_: UserAnswers) => true
+  protected val always: CreateAnswers => Boolean = (_: CreateAnswers) => true
 
-  protected val hasDutyType: ReclaimDutyType => UserAnswers => Boolean = (dutyType: ReclaimDutyType) =>
+  protected val hasDutyType: ReclaimDutyType => CreateAnswers => Boolean = (dutyType: ReclaimDutyType) =>
     _.reclaimDutyTypes.contains(dutyType)
 
-  protected val hasNoUploads: UserAnswers => Boolean = _.uploads.isEmpty
+  protected val hasNoUploads: CreateAnswers => Boolean = _.uploads.isEmpty
 
-  protected val hasUploads: UserAnswers => Boolean = _.uploads.nonEmpty
+  protected val hasUploads: CreateAnswers => Boolean = _.uploads.nonEmpty
 
-  protected val isRepresentative: UserAnswers => Boolean = _.isRepresentative
+  protected val isRepresentative: CreateAnswers => Boolean = _.isRepresentative
 
-  protected val enterImporterEori: UserAnswers => Boolean = (answers: UserAnswers) =>
+  protected val enterImporterEori: CreateAnswers => Boolean = (answers: CreateAnswers) =>
     isRepresentative(answers) && answers.doesImporterHaveEori
 
 }
 
 protected trait Ordering {
 
-  protected val nextPageFor: (Seq[P], Page, UserAnswers) => Option[Page] = (pages, currentPage, userAnswers) =>
+  protected val nextPageFor: (Seq[P], Page, CreateAnswers) => Option[Page] = (pages, currentPage, userAnswers) =>
     after(pages, currentPage)
       .find(_.canAccessGiven(userAnswers))
       .map(_.page)

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/services/CacheDataService.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/services/CacheDataService.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.services
 
 import javax.inject.Inject
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.requests.IdentifierRequest
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CacheData, CreateClaimResponse, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CacheData, CreateAnswers, CreateClaimResponse}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.repositories.CacheDataRepository
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,20 +33,22 @@ class CacheDataService @Inject() (repository: CacheDataRepository)(implicit ec: 
         repository.set(data) map { _ => data }
     }
 
-  def getAnswers(implicit request: IdentifierRequest[_]): Future[UserAnswers] =
-    getCacheData map (_.answers)
+  def getCreateAnswers(implicit request: IdentifierRequest[_]): Future[CreateAnswers] =
+    getCacheData map (_.getCreateAnswers)
 
-  def updateAnswers(update: UserAnswers => UserAnswers)(implicit request: IdentifierRequest[_]): Future[UserAnswers] =
+  def updateCreateAnswers(
+    update: CreateAnswers => CreateAnswers
+  )(implicit request: IdentifierRequest[_]): Future[CreateAnswers] =
     getCacheData flatMap { data =>
-      val updatedAnswers: UserAnswers = update(data.answers)
-      repository.set(data.copy(answers = updatedAnswers)) map { _ => updatedAnswers }
+      val updatedAnswers: CreateAnswers = update(data.getCreateAnswers)
+      repository.set(data.copy(createAnswers = Some(updatedAnswers))) map { _ => updatedAnswers }
     }
 
-  def updateResponse(
+  def updateCreateResponse(
     claimResponse: CreateClaimResponse
   )(implicit request: IdentifierRequest[_]): Future[Option[CacheData]] =
     getCacheData flatMap { data =>
-      repository.set(data.copy(answers = UserAnswers(), createClaimResponse = Some(claimResponse)))
+      repository.set(data.copy(createAnswers = None, createClaimResponse = Some(claimResponse)))
     }
 
 }

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/ControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/ControllerSpec.scala
@@ -24,7 +24,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, Request}
 import play.api.test.FakeRequest
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.FakeIdentifierActions
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CacheData, CreateClaimResponse, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CacheData, CreateAnswers, CreateClaimResponse}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.navigation.Navigator
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.repositories.CacheDataRepository
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.services.CacheDataService
@@ -59,8 +59,8 @@ trait ControllerSpec
 
   def withEmptyCache(): Unit = when(dataRepository.get(anyString())).thenReturn(Future.successful(None))
 
-  def withCacheUserAnswers(answers: UserAnswers): Unit = {
-    val cacheData: Option[CacheData] = Some(CacheData("id", answers = answers))
+  def withCacheCreateAnswers(answers: CreateAnswers): Unit = {
+    val cacheData: Option[CacheData] = Some(CacheData("id", createAnswers = Some(answers)))
     when(dataRepository.get(anyString())).thenReturn(Future.successful(cacheData))
   }
 
@@ -69,11 +69,11 @@ trait ControllerSpec
     when(dataRepository.get(anyString())).thenReturn(Future.successful(cacheData))
   }
 
-  protected def theUpdatedUserAnswers: UserAnswers = {
+  protected def theUpdatedCreateAnswers: CreateAnswers = {
     val captor = ArgumentCaptor.forClass(classOf[CacheData])
     verify(dataRepository).set(captor.capture())
     val cacheData: CacheData = captor.getValue
-    cacheData.answers
+    cacheData.getCreateAnswers
   }
 
   protected def postRequest(data: (String, String)*): Request[AnyContentAsFormUrlEncoded] =

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/TestData.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/TestData.scala
@@ -34,7 +34,7 @@ trait TestData {
   val fixedDateTime: LocalDateTime = LocalDateTime.now()
 
   // UserAnswers
-  val emptyAnswers: UserAnswers = UserAnswers()
+  val emptyAnswers: CreateAnswers = CreateAnswers()
 
   val representationTypeAnswer: RepresentationType = RepresentationType.Representative
 
@@ -86,7 +86,7 @@ trait TestData {
     "01234567890"
   )
 
-  val completeAnswers: UserAnswers = UserAnswers(
+  val completeAnswers: CreateAnswers = CreateAnswers(
     representationType = Some(representationTypeAnswer),
     claimType = Some(claimTypeAnswer),
     claimReason = Some(claimReasonAnswer),

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/KeepAliveControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/KeepAliveControllerSpec.scala
@@ -23,7 +23,7 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.ControllerSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.config.AppConfig
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CacheData, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CacheData, CreateAnswers}
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 class KeepAliveControllerSpec extends ControllerSpec {
@@ -36,7 +36,7 @@ class KeepAliveControllerSpec extends ControllerSpec {
   "GET /keep-alive" should {
 
     "update users session and data cache" in {
-      withCacheUserAnswers(UserAnswers())
+      withCacheCreateAnswers(CreateAnswers())
       val result = controller(fakeAuthorisedIdentifierAction).keepAlive(fakeGetRequest)
       status(result) mustBe Status.OK
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/StartControllerSpec.scala
@@ -20,7 +20,7 @@ import play.api.http.Status
 import play.api.test.Helpers._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.ControllerSpec
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.actions.IdentifierAction
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.UserAnswers
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.CreateAnswers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.FirstPage
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
@@ -34,7 +34,7 @@ class StartControllerSpec extends ControllerSpec {
     "redirect to first question when user is authorised" in {
       val result = controller(fakeAuthorisedIdentifierAction).start(fakeGetRequest)
       status(result) mustBe Status.SEE_OTHER
-      redirectLocation(result) mustBe Some(navigator.nextPage(FirstPage, UserAnswers()).url)
+      redirectLocation(result) mustBe Some(navigator.nextPage(FirstPage, CreateAnswers()).url)
     }
 
     "redirect when user is unauthorised" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/AddressControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/AddressControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.AddressFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{Address, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{Address, CreateAnswers}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.AddressPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.AddressView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class AddressControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(claimantAddress = Some(addressAnswer)))
+      withCacheCreateAnswers(CreateAnswers(claimantAddress = Some(addressAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -92,11 +92,11 @@ class AddressControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.claimantAddress mustBe Some(addressAnswer)
+      theUpdatedCreateAnswers.claimantAddress mustBe Some(addressAnswer)
       redirectLocation(result) mustBe Some(navigator.nextPage(AddressPage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/BankDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/BankDetailsControllerSpec.scala
@@ -26,7 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.BankDetailsFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.bars.BARSResult
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{BankDetails, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{BankDetails, CreateAnswers}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.BankDetailsPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.services.BankAccountReputationService
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.BankDetailsView
@@ -80,7 +80,7 @@ class BankDetailsControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(bankDetails = Some(bankDetailsAnswer)))
+      withCacheCreateAnswers(CreateAnswers(bankDetails = Some(bankDetailsAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -98,11 +98,11 @@ class BankDetailsControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.bankDetails mustBe Some(bankDetailsAnswer)
+      theUpdatedCreateAnswers.bankDetails mustBe Some(bankDetailsAnswer)
       redirectLocation(result) mustBe Some(navigator.nextPage(BankDetailsPage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/CheckYourAnswersControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/CheckYourAnswersControllerSpec.scala
@@ -63,7 +63,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpec with TestData {
   "GET" should {
 
     "return OK when user has answered all questions" in {
-      withCacheUserAnswers(completeAnswers)
+      withCacheCreateAnswers(completeAnswers)
       val result = controller.onPageLoad()(fakeGetRequest)
 
       status(result) mustBe Status.OK
@@ -78,7 +78,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpec with TestData {
     }
 
     "redirect to start when answers missing" in {
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onPageLoad()(fakeGetRequest)
 
@@ -90,7 +90,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpec with TestData {
   "POST" should {
 
     "submit and redirect to confirmation page" in {
-      withCacheUserAnswers(completeAnswers)
+      withCacheCreateAnswers(completeAnswers)
       val result = controller.onSubmit()(postRequest())
 
       status(result) mustEqual SEE_OTHER

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimReasonControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimReasonControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.ClaimReasonFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ClaimReason, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ClaimReason, CreateAnswers}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ClaimReasonPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ClaimReasonView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class ClaimReasonControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(claimReason = Some(claimReasonAnswer)))
+      withCacheCreateAnswers(CreateAnswers(claimReason = Some(claimReasonAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -86,12 +86,12 @@ class ClaimReasonControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.claimReason mustBe Some(claimReasonAnswer)
-      redirectLocation(result) mustBe Some(navigator.nextPage(ClaimReasonPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.claimReason mustBe Some(claimReasonAnswer)
+      redirectLocation(result) mustBe Some(navigator.nextPage(ClaimReasonPage, theUpdatedCreateAnswers).url)
     }
 
     "return 400 (BAD REQUEST) when invalid data posted" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ClaimTypeControllerSpec.scala
@@ -26,7 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.ClaimTypeFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ClaimType.AntiDumping
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ClaimType, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ClaimType, CreateAnswers}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ClaimTypePage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ClaimTypeView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -73,7 +73,7 @@ class ClaimTypeControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(claimType = Some(AntiDumping)))
+      withCacheCreateAnswers(CreateAnswers(claimType = Some(AntiDumping)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -87,11 +87,11 @@ class ClaimTypeControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.claimType mustBe Some(AntiDumping)
+      theUpdatedCreateAnswers.claimType mustBe Some(AntiDumping)
       redirectLocation(result) mustBe Some(navigator.nextPage(ClaimTypePage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ContactDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ContactDetailsControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.ContactDetailsFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ContactDetails, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ContactDetails, CreateAnswers}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ContactDetailsPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ContactDetailsView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class ContactDetailsControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(contactDetails = Some(contactDetailsAnswer)))
+      withCacheCreateAnswers(CreateAnswers(contactDetails = Some(contactDetailsAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -91,11 +91,11 @@ class ContactDetailsControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.contactDetails mustBe Some(contactDetailsAnswer)
+      theUpdatedCreateAnswers.contactDetails mustBe Some(contactDetailsAnswer)
       redirectLocation(result) mustBe Some(navigator.nextPage(ContactDetailsPage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/DutyRepaymentControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/DutyRepaymentControllerSpec.scala
@@ -26,7 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.DutyPaidFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.{Customs, Other, Vat}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{DutyPaid, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, DutyPaid}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.{
   CustomsDutyRepaymentPage,
   ImportVatRepaymentPage,
@@ -79,7 +79,7 @@ class DutyRepaymentControllerSpec extends ControllerSpec with TestData {
     "display page when cache has answer" when {
 
       "loading customs duty" in {
-        withCacheUserAnswers(UserAnswers(reclaimDutyPayments = reclaimDutyPayments))
+        withCacheCreateAnswers(CreateAnswers(reclaimDutyPayments = reclaimDutyPayments))
         val result = controller.onPageLoadCustomsDuty()(fakeGetRequest)
         status(result) mustBe Status.OK
 
@@ -87,7 +87,7 @@ class DutyRepaymentControllerSpec extends ControllerSpec with TestData {
       }
 
       "loading import vat" in {
-        withCacheUserAnswers(UserAnswers(reclaimDutyPayments = reclaimDutyPayments))
+        withCacheCreateAnswers(CreateAnswers(reclaimDutyPayments = reclaimDutyPayments))
         val result = controller.onPageLoadImportVat()(fakeGetRequest)
         status(result) mustBe Status.OK
 
@@ -95,7 +95,7 @@ class DutyRepaymentControllerSpec extends ControllerSpec with TestData {
       }
 
       "loading other duty" in {
-        withCacheUserAnswers(UserAnswers(reclaimDutyPayments = reclaimDutyPayments))
+        withCacheCreateAnswers(CreateAnswers(reclaimDutyPayments = reclaimDutyPayments))
         val result = controller.onPageLoadOtherDuty()(fakeGetRequest)
         status(result) mustBe Status.OK
 
@@ -112,32 +112,32 @@ class DutyRepaymentControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when customs duty answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmitCustomsDuty()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.reclaimDutyPayments mustBe Map(Customs.toString -> dutyPaid)
-      redirectLocation(result) mustBe Some(navigator.nextPage(CustomsDutyRepaymentPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.reclaimDutyPayments mustBe Map(Customs.toString -> dutyPaid)
+      redirectLocation(result) mustBe Some(navigator.nextPage(CustomsDutyRepaymentPage, theUpdatedCreateAnswers).url)
     }
 
     "update cache and redirect when import VAT answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmitImportVat()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.reclaimDutyPayments mustBe Map(Vat.toString -> dutyPaid)
-      redirectLocation(result) mustBe Some(navigator.nextPage(ImportVatRepaymentPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.reclaimDutyPayments mustBe Map(Vat.toString -> dutyPaid)
+      redirectLocation(result) mustBe Some(navigator.nextPage(ImportVatRepaymentPage, theUpdatedCreateAnswers).url)
     }
 
     "update cache and redirect when other duty answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmitOtherDuty()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.reclaimDutyPayments mustBe Map(Other.toString -> dutyPaid)
-      redirectLocation(result) mustBe Some(navigator.nextPage(OtherDutyRepaymentPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.reclaimDutyPayments mustBe Map(Other.toString -> dutyPaid)
+      redirectLocation(result) mustBe Some(navigator.nextPage(OtherDutyRepaymentPage, theUpdatedCreateAnswers).url)
     }
 
     "return 400 (BAD REQUEST) when invalid data posted" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/EntryDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/EntryDetailsControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.EntryDetailsFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{EntryDetails, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, EntryDetails}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.EntryDetailsPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.EntryDetailsView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class EntryDetailsControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(entryDetails = Some(entryDetailsAnswer)))
+      withCacheCreateAnswers(CreateAnswers(entryDetails = Some(entryDetailsAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -92,11 +92,11 @@ class EntryDetailsControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.entryDetails mustBe Some(entryDetailsAnswer)
+      theUpdatedCreateAnswers.entryDetails mustBe Some(entryDetailsAnswer)
       redirectLocation(result) mustBe Some(navigator.nextPage(EntryDetailsPage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterDetailsControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterDetailsControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.ImporterDetailsFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ImporterContactDetails, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, ImporterContactDetails}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ImporterContactDetailsPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ImporterDetailsView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class ImporterDetailsControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(importerContactDetails = Some(importerContactDetailsAnswer)))
+      withCacheCreateAnswers(CreateAnswers(importerContactDetails = Some(importerContactDetailsAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -94,12 +94,12 @@ class ImporterDetailsControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.importerContactDetails mustBe Some(importerContactDetailsAnswer)
-      redirectLocation(result) mustBe Some(navigator.nextPage(ImporterContactDetailsPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.importerContactDetails mustBe Some(importerContactDetailsAnswer)
+      redirectLocation(result) mustBe Some(navigator.nextPage(ImporterContactDetailsPage, theUpdatedCreateAnswers).url)
     }
 
     "return 400 (BAD REQUEST) when invalid data posted" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterEoriNumberControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterEoriNumberControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.EoriNumberFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{EoriNumber, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, EoriNumber}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ImporterEoriNumberPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ImporterEoriNumberView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class ImporterEoriNumberControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(importerEori = Some(importerEoriNumberAnswer)))
+      withCacheCreateAnswers(CreateAnswers(importerEori = Some(importerEoriNumberAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -86,12 +86,12 @@ class ImporterEoriNumberControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.importerEori mustBe Some(importerEoriNumberAnswer)
-      redirectLocation(result) mustBe Some(navigator.nextPage(ImporterEoriNumberPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.importerEori mustBe Some(importerEoriNumberAnswer)
+      redirectLocation(result) mustBe Some(navigator.nextPage(ImporterEoriNumberPage, theUpdatedCreateAnswers).url)
     }
 
     "return 400 (BAD REQUEST) when invalid data posted" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterHasEoriControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ImporterHasEoriControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.YesNoFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.UserAnswers
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.CreateAnswers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.RepayToPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ImporterHasEoriView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class ImporterHasEoriControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has positive answer" in {
-      withCacheUserAnswers(UserAnswers(importerHasEori = Some(true)))
+      withCacheCreateAnswers(CreateAnswers(importerHasEori = Some(true)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -80,7 +80,7 @@ class ImporterHasEoriControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has negative answer" in {
-      withCacheUserAnswers(UserAnswers(importerHasEori = Some(false)))
+      withCacheCreateAnswers(CreateAnswers(importerHasEori = Some(false)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -94,11 +94,11 @@ class ImporterHasEoriControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.importerHasEori mustBe Some(true)
+      theUpdatedCreateAnswers.importerHasEori mustBe Some(true)
       redirectLocation(result) mustBe Some(navigator.nextPage(RepayToPage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ItemNumbersControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ItemNumbersControllerSpec.scala
@@ -25,7 +25,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.ItemNumbersFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ItemNumbers, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, ItemNumbers}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ItemNumbersPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ItemNumbersView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -72,7 +72,7 @@ class ItemNumbersControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(itemNumbers = Some(itemNumbersAnswer)))
+      withCacheCreateAnswers(CreateAnswers(itemNumbers = Some(itemNumbersAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -86,12 +86,12 @@ class ItemNumbersControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.itemNumbers mustBe Some(itemNumbersAnswer)
-      redirectLocation(result) mustBe Some(navigator.nextPage(ItemNumbersPage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.itemNumbers mustBe Some(itemNumbersAnswer)
+      redirectLocation(result) mustBe Some(navigator.nextPage(ItemNumbersPage, theUpdatedCreateAnswers).url)
     }
 
     "return 400 (BAD REQUEST) when invalid data posted" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ReclaimDutyTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/ReclaimDutyTypeControllerSpec.scala
@@ -26,7 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.ReclaimDutyTypeFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.Customs
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ReclaimDutyType, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, ReclaimDutyType}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.ReclaimDutyTypePage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.ReclaimDutyTypeView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -73,7 +73,7 @@ class ReclaimDutyTypeControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(reclaimDutyTypes = reclaimDutyTypesAnswer))
+      withCacheCreateAnswers(CreateAnswers(reclaimDutyTypes = reclaimDutyTypesAnswer))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -87,12 +87,12 @@ class ReclaimDutyTypeControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.reclaimDutyTypes mustBe Set(Customs)
-      redirectLocation(result) mustBe Some(navigator.nextPage(ReclaimDutyTypePage, theUpdatedUserAnswers).url)
+      theUpdatedCreateAnswers.reclaimDutyTypes mustBe Set(Customs)
+      redirectLocation(result) mustBe Some(navigator.nextPage(ReclaimDutyTypePage, theUpdatedCreateAnswers).url)
     }
 
     "return 400 (BAD REQUEST) when invalid data posted" in {

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepayToControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepayToControllerSpec.scala
@@ -26,7 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.RepayToFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.RepayTo.Representative
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{RepayTo, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, RepayTo}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.RepayToPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.RepayToView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -73,7 +73,7 @@ class RepayToControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(repayTo = Some(Representative)))
+      withCacheCreateAnswers(CreateAnswers(repayTo = Some(Representative)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -87,11 +87,11 @@ class RepayToControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.repayTo mustBe Some(Representative)
+      theUpdatedCreateAnswers.repayTo mustBe Some(Representative)
       redirectLocation(result) mustBe Some(navigator.nextPage(RepayToPage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepresentationTypeControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/RepresentationTypeControllerSpec.scala
@@ -26,7 +26,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.RepresentationTypeFormProvider
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.RepresentationType.Representative
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{RepresentationType, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{CreateAnswers, RepresentationType}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.RepresentationTypePage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.RepresentationTypeView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -73,7 +73,7 @@ class RepresentationTypeControllerSpec extends ControllerSpec with TestData {
     }
 
     "display page when cache has answer" in {
-      withCacheUserAnswers(UserAnswers(representationType = Some(Representative)))
+      withCacheCreateAnswers(CreateAnswers(representationType = Some(Representative)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
 
@@ -87,11 +87,11 @@ class RepresentationTypeControllerSpec extends ControllerSpec with TestData {
 
     "update cache and redirect when valid answer is submitted" in {
 
-      withCacheUserAnswers(emptyAnswers)
+      withCacheCreateAnswers(emptyAnswers)
 
       val result = controller.onSubmit()(validRequest)
       status(result) mustEqual SEE_OTHER
-      theUpdatedUserAnswers.representationType mustBe Some(Representative)
+      theUpdatedCreateAnswers.representationType mustBe Some(Representative)
       redirectLocation(result) mustBe Some(navigator.nextPage(RepresentationTypePage, emptyAnswers).url)
     }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/UploadFormControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/UploadFormControllerSpec.scala
@@ -62,7 +62,7 @@ class UploadFormControllerSpec extends ControllerSpec with TestData {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
-    withCacheUserAnswers(emptyAnswers)
+    withCacheCreateAnswers(emptyAnswers)
 
     when(mockInitiateConnector.initiateV2(any[JourneyId], any(), any())(any())).thenReturn(
       Future.successful(upscanInitiateResponse)
@@ -107,7 +107,7 @@ class UploadFormControllerSpec extends ControllerSpec with TestData {
     "produce back link" when {
 
       "user has not uploaded any files" in {
-        withCacheUserAnswers(completeAnswers.copy(uploads = Seq.empty))
+        withCacheCreateAnswers(completeAnswers.copy(uploads = Seq.empty))
         val result = controller.onPageLoad()(fakeGetRequest)
         status(result) mustBe OK
 
@@ -115,7 +115,7 @@ class UploadFormControllerSpec extends ControllerSpec with TestData {
       }
 
       "user has uploaded some files" in {
-        withCacheUserAnswers(completeAnswers)
+        withCacheCreateAnswers(completeAnswers)
         val result = controller.onPageLoad()(fakeGetRequest)
         status(result) mustBe OK
 
@@ -148,7 +148,7 @@ class UploadFormControllerSpec extends ControllerSpec with TestData {
 
     "redirect when uploading a duplicate file" in {
 
-      withCacheUserAnswers(completeAnswers.copy(uploads = Seq(uploadAnswer)))
+      withCacheCreateAnswers(completeAnswers.copy(uploads = Seq(uploadAnswer)))
       givenUploadStatus(uploadFileSuccess)
       val result = controller.onProgress(uploadId)(fakeGetRequest)
 
@@ -166,13 +166,13 @@ class UploadFormControllerSpec extends ControllerSpec with TestData {
       status(result) mustBe SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.makeclaim.routes.UploadFormSummaryController.onPageLoad().url)
 
-      theUpdatedUserAnswers.uploads mustBe Seq(uploadFileSuccess)
+      theUpdatedCreateAnswers.uploads mustBe Seq(uploadFileSuccess)
     }
 
     "produce back link" when {
 
       "user has not uploaded any files" in {
-        withCacheUserAnswers(completeAnswers.copy(uploads = Seq.empty))
+        withCacheCreateAnswers(completeAnswers.copy(uploads = Seq.empty))
         givenUploadStatus(uploadInProgress)
         val result = controller.onProgress(uploadId)(fakeGetRequest)
         status(result) mustBe OK
@@ -181,7 +181,7 @@ class UploadFormControllerSpec extends ControllerSpec with TestData {
       }
 
       "user has uploaded some files" in {
-        withCacheUserAnswers(completeAnswers)
+        withCacheCreateAnswers(completeAnswers)
         givenUploadStatus(uploadInProgress)
         val result = controller.onProgress(uploadId)(fakeGetRequest)
         status(result) mustBe OK

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/UploadFormSummaryControllerSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/controllers/makeclaim/UploadFormSummaryControllerSpec.scala
@@ -24,7 +24,7 @@ import play.twirl.api.HtmlFormat
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{ControllerSpec, TestData}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.forms.YesNoFormProvider
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.UserAnswers
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.CreateAnswers
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages.UploadSummaryPage
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.views.html.makeclaim.UploadSummaryView
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
@@ -47,7 +47,7 @@ class UploadFormSummaryControllerSpec extends ControllerSpec with TestData {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
-    withCacheUserAnswers(emptyAnswers)
+    withCacheCreateAnswers(emptyAnswers)
 
     when(formPage.apply(any(), any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
@@ -61,13 +61,13 @@ class UploadFormSummaryControllerSpec extends ControllerSpec with TestData {
 
     "display page when cache contains uploads" in {
 
-      withCacheUserAnswers(UserAnswers(uploads = Seq(uploadAnswer)))
+      withCacheCreateAnswers(CreateAnswers(uploads = Seq(uploadAnswer)))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustBe Status.OK
     }
 
     "redirect when cache does not contain uploads" in {
-      withCacheUserAnswers(UserAnswers(uploads = Seq.empty))
+      withCacheCreateAnswers(CreateAnswers(uploads = Seq.empty))
       val result = controller.onPageLoad()(fakeGetRequest)
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.makeclaim.routes.UploadFormController.onPageLoad().url)
@@ -98,12 +98,12 @@ class UploadFormSummaryControllerSpec extends ControllerSpec with TestData {
   "onDelete" should {
 
     "remove uploaded document" in {
-      withCacheUserAnswers(UserAnswers(uploads = Seq(uploadAnswer, uploadAnswer2)))
+      withCacheCreateAnswers(CreateAnswers(uploads = Seq(uploadAnswer, uploadAnswer2)))
       val result = controller.onRemove(uploadAnswer.upscanReference)(postRequest())
       status(result) mustEqual SEE_OTHER
       redirectLocation(result) mustBe Some(controllers.makeclaim.routes.UploadFormSummaryController.onPageLoad().url)
 
-      theUpdatedUserAnswers.uploads mustBe Seq(uploadAnswer2)
+      theUpdatedCreateAnswers.uploads mustBe Seq(uploadAnswer2)
     }
   }
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/ClaimSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/ClaimSpec.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models
 
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{TestData, UnitSpec}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.{Customs, Other, Vat}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingUserAnswersException
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.exceptions.MissingAnswersException
 
 class ClaimSpec extends UnitSpec with TestData {
 
@@ -28,7 +28,7 @@ class ClaimSpec extends UnitSpec with TestData {
 
       "reclaim Customs Duty specified but no calculations present" in {
 
-        intercept[MissingUserAnswersException] {
+        intercept[MissingAnswersException] {
           Claim(completeAnswers.copy(reclaimDutyPayments = reclaimDutyPayments - Customs))
         }.getMessage mustBe s"Missing answer - DutyPayment $Customs"
 
@@ -36,7 +36,7 @@ class ClaimSpec extends UnitSpec with TestData {
 
       "reclaim Import VAT specified but no calculations present" in {
 
-        intercept[MissingUserAnswersException] {
+        intercept[MissingAnswersException] {
           Claim(completeAnswers.copy(reclaimDutyPayments = reclaimDutyPayments - Vat))
         }.getMessage mustBe s"Missing answer - DutyPayment $Vat"
 
@@ -44,7 +44,7 @@ class ClaimSpec extends UnitSpec with TestData {
 
       "reclaim Other Duty specified but no calculations present" in {
 
-        intercept[MissingUserAnswersException] {
+        intercept[MissingAnswersException] {
           Claim(completeAnswers.copy(reclaimDutyPayments = reclaimDutyPayments - Other))
         }.getMessage mustBe s"Missing answer - DutyPayment $Other"
 
@@ -53,7 +53,7 @@ class ClaimSpec extends UnitSpec with TestData {
       "representation type is 'representative' but 'repay to' is missing" in {
         val invalidAnswer =
           completeAnswers.copy(representationType = Some(RepresentationType.Representative), repayTo = None)
-        intercept[MissingUserAnswersException] {
+        intercept[MissingAnswersException] {
           Claim(invalidAnswer)
         }.getMessage mustBe s"Missing answer - RepayToPage"
 

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/navigation/NavigatorSpec.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/navigation/NavigatorSpec.scala
@@ -21,7 +21,11 @@ import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.base.{TestData, Un
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.controllers.makeclaim.routes
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.ReclaimDutyType.{Customs, Other, Vat}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.upscan.UploadedFile
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{ReclaimDutyType, RepresentationType, UserAnswers}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{
+  CreateAnswers,
+  ReclaimDutyType,
+  RepresentationType
+}
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.pages._
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.utils.Injector
 
@@ -29,10 +33,10 @@ class NavigatorSpec extends UnitSpec with Injector with TestData {
 
   private val navigator = instanceOf[Navigator]
 
-  private def answers(reclaim: ReclaimDutyType*): UserAnswers =
+  private def answers(reclaim: ReclaimDutyType*): CreateAnswers =
     completeAnswers.copy(reclaimDutyTypes = Set(reclaim: _*))
 
-  private def back(page: Page, userAnswers: UserAnswers): Call =
+  private def back(page: Page, userAnswers: CreateAnswers): Call =
     navigator.previousPage(page, userAnswers).maybeCall.getOrElse(Call("GET", "No back page"))
 
   "Navigator from address page" when {
@@ -188,7 +192,7 @@ class NavigatorSpec extends UnitSpec with Injector with TestData {
 
   "Navigating around file uploads" when {
 
-    def answers(uploads: Seq[UploadedFile]): UserAnswers =
+    def answers(uploads: Seq[UploadedFile]): CreateAnswers =
       completeAnswers.copy(uploads = uploads)
 
     val nextPage     = navigator.nextPage(ClaimReasonPage, _)


### PR DESCRIPTION
- rename UserAnswers to CreateAnswers
- make CreateAnswers optional on the CacheData (mongo db) model
- move the responsibility for creating new default CreateAnswers from CacheData constructor to accessor method
- rename methods in CacheDataService to reflect what is being got/updated