### PR TITLE
NF-393 Fix serialisation of UploadDetails

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/repositories/UploadRepository.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/repositories/UploadRepository.scala
@@ -47,8 +47,8 @@ case class UploadDetails(
 
 object UploadDetails {
 
-  implicit private val formatCreated: Format[Instant]   = MongoJavatimeFormats.instantFormat
-  
+  implicit private val formatCreated: Format[Instant] = MongoJavatimeFormats.instantFormat
+
   val uploadedSuccessfullyFormat: OFormat[UploadedFile] = Json.format[UploadedFile]
   val uploadedFailedFormat: OFormat[Failed]             = Json.format[Failed]
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/repositories/UploadRepository.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/repositories/UploadRepository.scala
@@ -47,10 +47,10 @@ case class UploadDetails(
 
 object UploadDetails {
 
+  implicit private val formatCreated: Format[Instant]   = MongoJavatimeFormats.instantFormat
+  
   val uploadedSuccessfullyFormat: OFormat[UploadedFile] = Json.format[UploadedFile]
   val uploadedFailedFormat: OFormat[Failed]             = Json.format[Failed]
-
-  implicit private val formatCreated: Format[Instant] = MongoJavatimeFormats.instantFormat
 
   val read: Reads[UploadStatus] = (json: JsValue) => {
     val jsObject = json.asInstanceOf[JsObject]


### PR DESCRIPTION
Ensures the implicit formatCreated serializer is declared before it is referenced (by the uploadedSuccessfullyFormat serializer)