### PR TITLE
BAU - upload document browser back fix

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/components/uploadForm.scala.html
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/views/components/uploadForm.scala.html
@@ -52,6 +52,7 @@
         id = "upload-file",
         attributes = Map(
             "accept" -> appConfig.upscan.approvedFileExtensions,
+            "autocomplete" -> "off",
             "onchange" -> "javascript:onFileSelect()"
         ),
         label = Label(


### PR DESCRIPTION
Fixes a problem when the user clicks the browser back button after a file has been uploaded.  This prevents the previously uploaded file being uploaded again (and the user getting "duplicate file" error.