### PR TITLE
Remove file transfer results from the create and amend journey audit.…

### DIFF
--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/amend/AmendClaimAudit.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/amend/AmendClaimAudit.scala
@@ -25,7 +25,6 @@ case class AmendClaimAudit(
   claimantEori: String,
   caseReferenceNumber: String,
   uploads: Seq[UploadedFile],
-  fileTransferResults: Seq[FileTransferResult],
   furtherInformation: String
 )
 
@@ -44,7 +43,6 @@ object AmendClaimAudit {
       claimantEori.number,
       claim.caseReference.number,
       claim.uploads,
-      claimResponse.result.map(result => result.fileTransferResults).getOrElse(Seq.empty),
       claim.furtherInformation.info
     )
 

--- a/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/create/CreateClaimAudit.scala
+++ b/app/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/models/create/CreateClaimAudit.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.create
 
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.{EoriNumber, FileTransferResult}
+import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.EoriNumber
 import uk.gov.hmrc.nationalimportdutyadjustmentcentrefrontend.models.upscan.UploadedFile
 
 case class CreateClaimAudit(
@@ -35,7 +35,6 @@ case class CreateClaimAudit(
   entryDetails: EntryDetails,
   itemNumbers: ItemNumbers,
   uploads: Seq[UploadedFile],
-  fileTransferResults: Seq[FileTransferResult],
   claimantEori: String,
   importerEori: Option[EoriNumber]
 )
@@ -60,7 +59,6 @@ object CreateClaimAudit {
       claim.entryDetails,
       claim.itemNumbers,
       claim.uploads,
-      claimResponse.result.map(result => result.fileTransferResults).getOrElse(Seq.empty),
       claim.claimantEori.number,
       claim.importerBeingRepresentedDetails.flatMap(details => details.eoriNumber)
     )

--- a/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/TestData.scala
+++ b/test/uk/gov/hmrc/nationalimportdutyadjustmentcentrefrontend/base/TestData.scala
@@ -264,11 +264,6 @@ trait TestData {
     entryDetailsAnswer,
     itemNumbersAnswer,
     Seq(uploadAnswer),
-    Seq(
-      new FileTransferResult("up-ref-1", true, 201, fixedInstant, None),
-      new FileTransferResult("up-ref-2", true, 201, fixedInstant, None),
-      new FileTransferResult("up-ref-3", true, 201, fixedInstant, None)
-    ),
     claimantEori.number,
     Some(importerEoriNumberAnswer)
   )
@@ -278,10 +273,6 @@ trait TestData {
     claimantEori.number,
     "NID21134557697RM8WIB13",
     Seq(uploadAnswer, uploadAnswer2),
-    Seq(
-      new FileTransferResult("up-ref-1", true, 201, fixedInstant, None),
-      new FileTransferResult("up-ref-2", true, 201, fixedInstant, None)
-    ),
     furtherInformationAnswer.info
   )
 


### PR DESCRIPTION
… They are now audited by the back end.